### PR TITLE
fix(ui): vitest lint 세팅 오류 수정

### DIFF
--- a/packages/eslint-config-custom/package.json
+++ b/packages/eslint-config-custom/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "devDependencies": {
     "@vercel/style-guide": "^5.0.0",
-    "eslint-config-turbo": "^1.10.12"
+    "eslint-config-turbo": "^1.10.12",
+    "eslint-plugin-vitest": "^0.5.4"
   }
 }

--- a/packages/eslint-config-custom/react-internal.js
+++ b/packages/eslint-config-custom/react-internal.js
@@ -17,7 +17,6 @@ module.exports = {
     '@vercel/style-guide/eslint/browser',
     '@vercel/style-guide/eslint/typescript',
     '@vercel/style-guide/eslint/react',
-    '@vercel/style-guide/eslint/vitest',
   ].map(require.resolve),
   parserOptions: {
     project,

--- a/packages/ui/.eslintrc.js
+++ b/packages/ui/.eslintrc.js
@@ -1,3 +1,9 @@
+const vitest = require('eslint-plugin-vitest');
+
 module.exports = {
-  extends: ["custom/react-internal"],
+  extends: ['custom/react-internal'],
+  plugins: ['vitest'],
+  rules: {
+    ...vitest.configs.recommended.rules,
+  },
 };

--- a/packages/ui/Dialog/types.ts
+++ b/packages/ui/Dialog/types.ts
@@ -1,7 +1,6 @@
 import type { ReactNode } from 'react';
 import type React from 'react';
-
-import { CheckBoxProps } from 'Control/CheckBox';
+import type { CheckBoxProps } from 'Control/CheckBox';
 
 
 export interface ChildrenProp {

--- a/turbo.json
+++ b/turbo.json
@@ -6,7 +6,9 @@
       "dependsOn": ["^build"],
       "outputs": [".next/**", "!.next/cache/**", "dist/**"]
     },
-    "lint": {},
+    "lint": {
+      "cache": false
+    },
     "dev": {
       "cache": false,
       "persistent": true

--- a/turbo.json
+++ b/turbo.json
@@ -13,6 +13,8 @@
       "cache": false,
       "persistent": true
     },
-    "test": {}
+    "test": {
+      "cache": false
+    }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5487,6 +5487,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/scope-manager@npm:7.18.0":
+  version: 7.18.0
+  resolution: "@typescript-eslint/scope-manager@npm:7.18.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:7.18.0"
+    "@typescript-eslint/visitor-keys": "npm:7.18.0"
+  checksum: 10c0/038cd58c2271de146b3a594afe2c99290034033326d57ff1f902976022c8b0138ffd3cb893ae439ae41003b5e4bcc00cabf6b244ce40e8668f9412cc96d97b8e
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/type-utils@npm:6.21.0":
   version: 6.21.0
   resolution: "@typescript-eslint/type-utils@npm:6.21.0"
@@ -5515,6 +5525,13 @@ __metadata:
   version: 6.21.0
   resolution: "@typescript-eslint/types@npm:6.21.0"
   checksum: 10c0/020631d3223bbcff8a0da3efbdf058220a8f48a3de221563996ad1dcc30d6c08dadc3f7608cc08830d21c0d565efd2db19b557b9528921c78aabb605eef2d74d
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/types@npm:7.18.0":
+  version: 7.18.0
+  resolution: "@typescript-eslint/types@npm:7.18.0"
+  checksum: 10c0/eb7371ac55ca77db8e59ba0310b41a74523f17e06f485a0ef819491bc3dd8909bb930120ff7d30aaf54e888167e0005aa1337011f3663dc90fb19203ce478054
   languageName: node
   linkType: hard
 
@@ -5555,6 +5572,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/typescript-estree@npm:7.18.0":
+  version: 7.18.0
+  resolution: "@typescript-eslint/typescript-estree@npm:7.18.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:7.18.0"
+    "@typescript-eslint/visitor-keys": "npm:7.18.0"
+    debug: "npm:^4.3.4"
+    globby: "npm:^11.1.0"
+    is-glob: "npm:^4.0.3"
+    minimatch: "npm:^9.0.4"
+    semver: "npm:^7.6.0"
+    ts-api-utils: "npm:^1.3.0"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/0c7f109a2e460ec8a1524339479cf78ff17814d23c83aa5112c77fb345e87b3642616291908dcddea1e671da63686403dfb712e4a4435104f92abdfddf9aba81
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/utils@npm:6.21.0":
   version: 6.21.0
   resolution: "@typescript-eslint/utils@npm:6.21.0"
@@ -5590,6 +5626,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/utils@npm:^7.7.1":
+  version: 7.18.0
+  resolution: "@typescript-eslint/utils@npm:7.18.0"
+  dependencies:
+    "@eslint-community/eslint-utils": "npm:^4.4.0"
+    "@typescript-eslint/scope-manager": "npm:7.18.0"
+    "@typescript-eslint/types": "npm:7.18.0"
+    "@typescript-eslint/typescript-estree": "npm:7.18.0"
+  peerDependencies:
+    eslint: ^8.56.0
+  checksum: 10c0/a25a6d50eb45c514469a01ff01f215115a4725fb18401055a847ddf20d1b681409c4027f349033a95c4ff7138d28c3b0a70253dfe8262eb732df4b87c547bd1e
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/visitor-keys@npm:5.62.0":
   version: 5.62.0
   resolution: "@typescript-eslint/visitor-keys@npm:5.62.0"
@@ -5607,6 +5657,16 @@ __metadata:
     "@typescript-eslint/types": "npm:6.21.0"
     eslint-visitor-keys: "npm:^3.4.1"
   checksum: 10c0/7395f69739cfa1cb83c1fb2fad30afa2a814756367302fb4facd5893eff66abc807e8d8f63eba94ed3b0fe0c1c996ac9a1680bcbf0f83717acedc3f2bb724fbf
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:7.18.0":
+  version: 7.18.0
+  resolution: "@typescript-eslint/visitor-keys@npm:7.18.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:7.18.0"
+    eslint-visitor-keys: "npm:^3.4.3"
+  checksum: 10c0/538b645f8ff1d9debf264865c69a317074eaff0255e63d7407046176b0f6a6beba34a6c51d511f12444bae12a98c69891eb6f403c9f54c6c2e2849d1c1cb73c0
   languageName: node
   linkType: hard
 
@@ -8808,6 +8868,7 @@ __metadata:
   dependencies:
     "@vercel/style-guide": "npm:^5.0.0"
     eslint-config-turbo: "npm:^1.10.12"
+    eslint-plugin-vitest: "npm:^0.5.4"
   languageName: unknown
   linkType: soft
 
@@ -9093,6 +9154,23 @@ __metadata:
   peerDependencies:
     eslint: ">=8.44.0"
   checksum: 10c0/158a9fc41c213a2d4a4d7ed9c866c86f9f1901d7f7371c60f3e18d05be73cb6982b72c33a679955142116032127835f8550b466484885c0cedb2e7ed951136ac
+  languageName: node
+  linkType: hard
+
+"eslint-plugin-vitest@npm:^0.5.4":
+  version: 0.5.4
+  resolution: "eslint-plugin-vitest@npm:0.5.4"
+  dependencies:
+    "@typescript-eslint/utils": "npm:^7.7.1"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0
+    vitest: "*"
+  peerDependenciesMeta:
+    "@typescript-eslint/eslint-plugin":
+      optional: true
+    vitest:
+      optional: true
+  checksum: 10c0/b55cca2fee39e46fd9504f8fc6dbf790c4a63f2f4b77c013857954f9d6b5f5d3c4370314cba03367f34f40783d49a81763c0c16fd4e9689b28164569f2354591
   languageName: node
   linkType: hard
 
@@ -15440,7 +15518,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-api-utils@npm:^1.0.1":
+"ts-api-utils@npm:^1.0.1, ts-api-utils@npm:^1.3.0":
   version: 1.3.0
   resolution: "ts-api-utils@npm:1.3.0"
   peerDependencies:


### PR DESCRIPTION
## 변경사항

<!-- 어떤 변경사항이 있는지, PR 타이틀과 동일하다면 Skip -->

`release` 워크플로우에서 lint 스크립트 동작 과정에서 문제가 발생했어요.

<img width="1041" alt="image" src="https://github.com/user-attachments/assets/d891bbd6-9b2f-42cd-8895-360bc36a4583">

원인은 vitest lint 세팅을 하고자 `react-internal.js`에 추가했던 부분 때문이었어요.

```js
extends: [
  '@vercel/style-guide/eslint/browser',
  '@vercel/style-guide/eslint/typescript',
  '@vercel/style-guide/eslint/react',
  // 새로 추가한 부분
  '@vercel/style-guide/eslint/vitest,
].map(require.resolve),
```

패키지 코드에는 분명히 `vitest.js`가 존재했는데, 알고보니 저희 패키지에 설치된 `@vercel/style-guide`의 버전은 `5.0.0`이었고, Vitest eslint rule이 릴리즈된 버전은 `6.0.0` 버전이어서 오류가 발생했던 것이었어요.

<img width="500" alt="image" src="https://github.com/user-attachments/assets/35c0df58-ae44-49fc-b7fc-4516e661ea0b">


그래서 latest 버전으로 업그레이드를 시도했는데, 문제가 많이 발생했어요.

latest 버전으로 업그레이드하게 되면 업그레이드한 패키지가 의존하는 vite 버전과 기존에 설치된 패키지가 요구하는 vite 버전에 충돌이 발생하게 돼요. 
lock파일 임의 변경도 금지되어 있어 여러모로 의존성 충돌을 해결하기 어려운 상황이라 `vitest`가 사용되는 `ui` 패키지 내부의 `eslint` 파일에서 직접 rule을 세팅해주기로 했어요.

4달 전 `eslint-plugin-vitest`라는 플러그인이 개발되어서 이걸 사용해서 lint 세팅을 해주었어요.

```js
// packages/ui/eslintrc.js

const vitest = require('eslint-plugin-vitest');

module.exports = {
  extends: ['custom/react-internal'],
  plugins: ['vitest'],
  rules: {
    ...vitest.configs.recommended.rules,
  },
};
```

그 후 lint 스크립트 동작시켰더니 오류가 발생하지 않았어요.

<img width="402" alt="image" src="https://github.com/user-attachments/assets/885995fe-e64b-496f-be56-6b952cd9318f">


fork한 레포에서 workflow 테스트도 해보았는데 잘 동작하는 것을 확인했어요.

<img width="1125" alt="image" src="https://github.com/user-attachments/assets/0863d6d8-7258-43ec-a187-c238bd4fce38">

### 추가 작업

-  기존에 lint rule이 어긋난 부분이 두 군데 있어서 `--fix` 스크립트로 수정해서 반영했어요.
- lint 커맨드 결과가 자꾸 캐싱되어서 의도적으로 오류를 발생시켰는데도 이전 성공 로그가 캐싱되어 성공했다고 출력이 되었어요. 사실 lint는 테스트 용도이기 때문에 결과가 캐싱되면 결과 확인에 혼선이 생길 수도 있다고 생각해서 `turbo.json`에서 cache 옵션을 비활성화시켰어요. 같은 이유로 test 커맨드도 cache 옵션을 비활성화시켰어요.

## 시급한 정도

🏃‍♂️ 보통 : 최대한 빠르게 리뷰 부탁드립니다.

