### PR TITLE
fix: release workflow에 pnpm setup action 추가

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,16 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 9
+
       - name: Setup Node.js 18
         uses: actions/setup-node@v3
         with:
           node-version: 18
+          cache: 'pnpm'
 
       - name: Install Dependencies
         run: pnpm install

--- a/package.json
+++ b/package.json
@@ -25,10 +25,6 @@
   "name": "makers-frontend",
   "version": "1.0.0",
   "packageManager": "pnpm@9.7.0",
-  "workspaces": [
-    "apps/*",
-    "packages/*"
-  ],
   "engines": {
     "node": ">=18",
     "pnpm": ">=9"


### PR DESCRIPTION
## 변경사항

<!-- 어떤 변경사항이 있는지, PR 타이틀과 동일하다면 Skip -->

`pnpm`으로 마이그레이션하면서 `release` workflow가 정상 동작하지 않았어요.

<img width="1106" alt="image" src="https://github.com/user-attachments/assets/ae26542d-2c52-49b8-b589-393a55d11555">

알아보니  `actions/setup-node` 액션을 사용하면 `Node.js`와 함께 `yarn`이 자동으로 설치되지만, pnpm은 그렇지 않다고 해요.
그래서 `pnpm/action-setup@v2` 액션을 추가하여 workflow에서 pnpm을 명시적으로 설치하고 사용할 수 있게 했어요.

<img width="1109" alt="image" src="https://github.com/user-attachments/assets/5fc6f993-2b0f-46a2-bc6c-02e0d47c1739">

그 결과 `release` workflow가 정상 동작하는 것을 확인했어요.

++ 추가 작업
`pnpm`으로 마이그레이션하면서 workspace를 `pnpm-workspace.yaml`이라는 별도의 파일에서 관리하게 되었는데, 아직 package.json에도 workspace 필드가 남아있어서 제거해주었습니다!

## 링크

<!-- 제플린 화면 링크 또는 관련된 대화가 이루어진 slack, height, figma 링크를 첨부. -->

## 시급한 정도

🏃‍♂️ 보통 : 최대한 빠르게 리뷰 부탁드립니다.

<!-- ⚠︎ 긴급 : 선 어프루브 후 리뷰를 부탁드립니다. (리뷰는 추후 반영)  -->
<!-- 🐢 천천히 : 급하지 않습니다. -->

## 기타 사항

<!-- 변경사항이 큰 경우 집중해야 할 부분, 또는 불안해서 봐주었으면 하는 부분 등 -->

<!-- ### AS-IS -->

<!-- ### TO-BE -->
