### PR TITLE
feat(Select): Select를서브 컴포넌트로 분리하여 구성

### DIFF
--- a/.changeset/spicy-ducks-beam.md
+++ b/.changeset/spicy-ducks-beam.md
@@ -1,0 +1,5 @@
+---
+'@sopt-makers/ui': minor
+---
+
+Input/SelectV2 컴포넌트 출시

--- a/packages/ui/Input/Select.tsx
+++ b/packages/ui/Input/Select.tsx
@@ -99,12 +99,12 @@ function SelectRoot<T extends string | number | boolean>(props: SelectProps<T>) 
   }, [handleToggleClose, open]);
 
   const handleOptionClick = (option: Option<T>) => {
+    setSelected(option);
+    handleToggleClose();
+
     if (onChange) {
       onChange(option.value);
     }
-
-    setSelected(option);
-    handleToggleClose();
   };
 
   const contextValue: SelectContextProps<T> = {
@@ -208,6 +208,7 @@ function SelectMenuItem<T>({ option, onClick }: SelectMenuItemProps<T>) {
 
   const handleClick = () => {
     handleOptionClick(option);
+
     if (onClick) {
       onClick();
     }
@@ -218,7 +219,7 @@ function SelectMenuItem<T>({ option, onClick }: SelectMenuItemProps<T>) {
   }
 
   return (
-    <li key={option.label}>
+    <li>
       <button className={S.option} onClick={handleClick} type='button'>
         {type === 'textIcon' && option.icon}
         {(type === 'userList' || type === 'userListDesc') &&

--- a/packages/ui/Input/Select.tsx
+++ b/packages/ui/Input/Select.tsx
@@ -12,7 +12,6 @@ export interface Option<T> {
 
 interface SelectProps<T> {
   className?: string;
-  placeholder?: string;
   type: 'text' | 'textDesc' | 'textIcon' | 'userList' | 'userListDesc';
   visibleOptions?: number;
   defaultValue?: Option<T>;
@@ -125,8 +124,6 @@ function SelectRoot<T extends string | number | boolean>(props: SelectProps<T>) 
   );
 }
 
-SelectRoot.displayName = 'Select.Root';
-
 // Select.Trigger 컴포넌트: 메뉴를 열고 닫는 trigger
 interface SelectTriggerProps {
   children: React.ReactNode;
@@ -145,8 +142,6 @@ function SelectTrigger({ children }: SelectTriggerProps) {
     </button>
   );
 }
-
-SelectTrigger.displayName = 'Select.Trigger';
 
 interface SelectTriggerContentProps {
   className?: string;
@@ -174,8 +169,6 @@ function SelectTriggerContent({ className, placeholder }: SelectTriggerContentPr
   );
 }
 
-SelectTriggerContent.displayName = 'Select.TriggerContent';
-
 interface SelectMenuProps {
   children: React.ReactNode;
 }
@@ -194,8 +187,6 @@ function SelectMenu({ children }: SelectMenuProps) {
     </ul>
   );
 }
-
-SelectMenu.displayName = 'Select.Menu';
 
 interface SelectMenuItemProps<T> {
   option: Option<T>;
@@ -239,8 +230,6 @@ function SelectMenuItem<T>({ option, onClick }: SelectMenuItemProps<T>) {
     </li>
   );
 }
-
-SelectMenuItem.displayName = 'Select.MenuItem';
 
 const Select = {
   Root: SelectRoot,

--- a/packages/ui/Input/Select.tsx
+++ b/packages/ui/Input/Select.tsx
@@ -160,13 +160,13 @@ interface SelectTriggerContentProps {
 
 // Select.TriggerContent 컴포넌트: trigger의 미리 정의된 UI
 function SelectTriggerContent({ className }: SelectTriggerContentProps) {
-  const { open, selected, options, placeholder } = useSelectContext();
+  const { open, selected, placeholder } = useSelectContext();
 
-  const selectedLabel = selected ? options.find((option) => option.value === selected.value)?.label : placeholder;
+  const selectedLabel = selected ? selected.label : placeholder;
 
   return (
     <div className={`${S.select} ${className ? className : ''}`}>
-      <p className={!selected ? S.selectPlaceholder : ''}>{selectedLabel}</p>{' '}
+      <p className={!selected ? S.selectPlaceholder : ''}>{selectedLabel}</p>
       <IconChevronDown
         style={{
           width: 20,
@@ -193,7 +193,13 @@ function SelectMenu() {
     <ul className={S.optionList} ref={optionsRef} style={{ maxHeight: calcMaxHeight() }}>
       {options.map((option) => (
         <li key={option.label}>
-          <button className={S.option} onClick={() => { handleOptionClick(option); }} type='button'>
+          <button
+            className={S.option}
+            onClick={() => {
+              handleOptionClick(option);
+            }}
+            type='button'
+          >
             {type === 'textIcon' && option.icon}
             {(type === 'userList' || type === 'userListDesc') &&
               (option.profileUrl ? (

--- a/packages/ui/Input/Select.tsx
+++ b/packages/ui/Input/Select.tsx
@@ -26,8 +26,6 @@ interface SelectContextProps<T> {
   selected: Option<T> | null;
   handleOptionClick: (option: Option<T>) => void;
   type: SelectProps<T>['type'];
-  visibleOptions: number;
-  placeholder?: string;
   onChange: (value: T) => void;
   buttonRef: React.RefObject<HTMLButtonElement>;
   optionsRef: React.RefObject<HTMLUListElement>;
@@ -48,7 +46,7 @@ function useSelectContext<T>() {
 
 // SelectRoot 컴포넌트: Select 컴포넌트에게 context를 제공
 function SelectRoot<T extends string | number | boolean>(props: SelectProps<T>) {
-  const { children, onChange, defaultValue, type, visibleOptions = 5, placeholder, className } = props;
+  const { children, onChange, defaultValue, type, visibleOptions = 5, className } = props;
 
   const buttonRef = useRef<HTMLButtonElement>(null);
   const optionsRef = useRef<HTMLUListElement>(null);
@@ -113,8 +111,6 @@ function SelectRoot<T extends string | number | boolean>(props: SelectProps<T>) 
     selected,
     handleOptionClick,
     type,
-    visibleOptions,
-    placeholder,
     onChange,
     buttonRef,
     optionsRef,
@@ -153,11 +149,12 @@ SelectTrigger.displayName = 'Select.Trigger';
 
 interface SelectTriggerContentProps {
   className?: string;
+  placeholder?: string;
 }
 
 // Select.TriggerContent 컴포넌트: trigger의 미리 정의된 UI
-function SelectTriggerContent({ className }: SelectTriggerContentProps) {
-  const { open, selected, placeholder } = useSelectContext();
+function SelectTriggerContent({ className, placeholder }: SelectTriggerContentProps) {
+  const { open, selected } = useSelectContext();
 
   const selectedLabel = selected ? selected.label : placeholder;
 

--- a/packages/ui/Input/Select.tsx
+++ b/packages/ui/Input/Select.tsx
@@ -16,7 +16,7 @@ interface SelectProps<T> {
   type: 'text' | 'textDesc' | 'textIcon' | 'userList' | 'userListDesc';
   visibleOptions?: number;
   defaultValue?: Option<T>;
-  onChange: (value: T) => void;
+  onChange?: (value: T) => void;
   children: React.ReactNode;
 }
 
@@ -26,7 +26,6 @@ interface SelectContextProps<T> {
   selected: Option<T> | null;
   handleOptionClick: (option: Option<T>) => void;
   type: SelectProps<T>['type'];
-  onChange: (value: T) => void;
   buttonRef: React.RefObject<HTMLButtonElement>;
   optionsRef: React.RefObject<HTMLUListElement>;
   calcMaxHeight: () => number;
@@ -100,8 +99,11 @@ function SelectRoot<T extends string | number | boolean>(props: SelectProps<T>) 
   }, [handleToggleClose, open]);
 
   const handleOptionClick = (option: Option<T>) => {
+    if (onChange) {
+      onChange(option.value);
+    }
+
     setSelected(option);
-    onChange(option.value);
     handleToggleClose();
   };
 
@@ -111,7 +113,6 @@ function SelectRoot<T extends string | number | boolean>(props: SelectProps<T>) 
     selected,
     handleOptionClick,
     type,
-    onChange,
     buttonRef,
     optionsRef,
     calcMaxHeight,

--- a/packages/ui/Input/Select.tsx
+++ b/packages/ui/Input/Select.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback } from 'react';
+import { useState, useRef, useEffect, useCallback, createContext, useContext } from 'react';
 import { IconChevronDown, IconUser } from '@sopt-makers/icons';
 import * as S from './style.css';
 
@@ -18,20 +18,45 @@ interface SelectProps<T> {
   visibleOptions?: number;
   defaultValue?: Option<T>;
   onChange: (value: T) => void;
+  children: React.ReactNode;
 }
 
-function Select<T extends string | number | boolean>(props: SelectProps<T>) {
-  const { className, placeholder, type, options, visibleOptions = 5, defaultValue, onChange } = props;
+interface SelectContextProps<T> {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  selected: Option<T> | null;
+  handleOptionClick: (option: Option<T>) => void;
+  options: Option<T>[];
+  type: SelectProps<T>['type'];
+  visibleOptions: number;
+  placeholder?: string;
+  onChange: (value: T) => void;
+  buttonRef: React.RefObject<HTMLButtonElement>;
+  optionsRef: React.RefObject<HTMLUListElement>;
+  calcMaxHeight: () => number;
+}
 
-  const optionsRef = useRef<HTMLUListElement>(null);
+// SelectContext: Select.root 하위 컴포넌트들이 사용할 Context
+const SelectContext = createContext({});
+
+// useSelectContext: Select 컴포넌트 외부에서 서브 컴포넌트들이 사용됐을 때 에러 처리
+function useSelectContext<T>() {
+  const context = useContext(SelectContext);
+  if (Object.keys(context).length === 0) {
+    throw new Error('Select 컴포넌트는 Select.Root 내에서 사용되어야 합니다.');
+  }
+  return context as SelectContextProps<T>;
+}
+
+// SelectRoot 컴포넌트: Select 컴포넌트에게 context를 제공
+function SelectRoot<T extends string | number | boolean>(props: SelectProps<T>) {
+  const { children, onChange, options, defaultValue, type, visibleOptions = 5, placeholder, className } = props;
+
   const buttonRef = useRef<HTMLButtonElement>(null);
+  const optionsRef = useRef<HTMLUListElement>(null);
 
   const [selected, setSelected] = useState<Option<T> | null>(defaultValue ?? null);
   const [open, setOpen] = useState(false);
-
-  const handleToggleOpen = useCallback(() => {
-    setOpen((prev) => !prev);
-  }, []);
 
   const handleToggleClose = useCallback(() => {
     setOpen(false);
@@ -67,69 +92,136 @@ function Select<T extends string | number | boolean>(props: SelectProps<T>) {
         handleToggleClose();
       }
     };
-    document.addEventListener('mousedown', handleClickOutside);
+    if (open) {
+      document.addEventListener('mousedown', handleClickOutside);
+    } else {
+      document.removeEventListener('mousedown', handleClickOutside);
+    }
 
     return () => {
       document.removeEventListener('mousedown', handleClickOutside);
     };
-  }, [handleToggleClose]);
+  }, [handleToggleClose, open]);
 
-  const handleOptionClick = (value: Option<T>) => {
-    setSelected(value);
-    onChange(value.value); // value 자체가 아닌 value.value를 onChange에 전달
+  const handleOptionClick = (option: Option<T>) => {
+    setSelected(option);
+    onChange(option.value);
     handleToggleClose();
   };
+
+  const contextValue: SelectContextProps<T> = {
+    open,
+    setOpen,
+    selected,
+    handleOptionClick,
+    options,
+    type,
+    visibleOptions,
+    placeholder,
+    onChange,
+    buttonRef,
+    optionsRef,
+    calcMaxHeight,
+  };
+
+  return (
+    <SelectContext.Provider value={contextValue}>
+      <div className={`${S.selectWrap} ${className}`}>{children}</div>
+    </SelectContext.Provider>
+  );
+}
+
+SelectRoot.displayName = 'Select.Root';
+
+// Select.Trigger 컴포넌트: 메뉴를 열고 닫는 trigger
+interface SelectTriggerProps {
+  children: React.ReactNode;
+}
+
+function SelectTrigger({ children }: SelectTriggerProps) {
+  const { open, setOpen, buttonRef } = useSelectContext();
+
+  const handleClick = () => {
+    setOpen(!open);
+  };
+
+  return (
+    <button className={S.buttonWithNoStyle} onClick={handleClick} ref={buttonRef} type='button'>
+      {children}
+    </button>
+  );
+}
+
+SelectTrigger.displayName = 'Select.Trigger';
+
+interface SelectTriggerContentProps {
+  className?: string;
+}
+
+// Select.TriggerContent 컴포넌트: trigger의 미리 정의된 UI
+function SelectTriggerContent({ className }: SelectTriggerContentProps) {
+  const { open, selected, options, placeholder } = useSelectContext();
 
   const selectedLabel = selected ? options.find((option) => option.value === selected.value)?.label : placeholder;
 
   return (
-    <div className={`${S.selectWrap} ${className}`}>
-      <button className={S.select} onClick={handleToggleOpen} ref={buttonRef} type='button'>
-        <p className={!selected ? S.selectPlaceholder : ''}>{selectedLabel}</p>
-        <IconChevronDown
-          style={{
-            width: 20,
-            height: 20,
-            transform: open ? 'rotate(-180deg)' : '',
-            transition: 'all 0.5s',
-          }}
-        />
-      </button>
-
-      {open ? (
-        <ul className={S.optionList} ref={optionsRef} style={{ maxHeight: calcMaxHeight() }}>
-          {options.map((option) => (
-            <li key={option.label}>
-              <button
-                className={S.option}
-                onClick={() => {
-                  handleOptionClick(option); // Option<T> 타입으로 전달
-                }}
-                type='button'
-              >
-                {type === 'textIcon' && option.icon}
-                {(type === 'userList' || type === 'userListDesc') &&
-                  (option.profileUrl ? (
-                    <img alt={option.label} className={S.optionProfileImg} src={option.profileUrl} />
-                  ) : (
-                    <div className={S.optionProfileEmpty}>
-                      <IconUser />
-                    </div>
-                  ))}
-
-                <div>
-                  <p>{option.label}</p>
-                  {(type === 'textDesc' || type === 'userListDesc') && (
-                    <p className={S.optionDesc}>{option.description}</p>
-                  )}
-                </div>
-              </button>
-            </li>
-          ))}
-        </ul>
-      ) : null}
+    <div className={`${S.select} ${className ? className : ''}`}>
+      <p className={!selected ? S.selectPlaceholder : ''}>{selectedLabel}</p>{' '}
+      <IconChevronDown
+        style={{
+          width: 20,
+          height: 20,
+          transform: open ? 'rotate(-180deg)' : '',
+          transition: 'all 0.3s ease',
+        }}
+      />
     </div>
   );
 }
+
+SelectTriggerContent.displayName = 'Select.TriggerContent';
+
+// SelectMenu 컴포넌트: 옵션 목록을 렌더링
+function SelectMenu() {
+  const { open, options, type, handleOptionClick, optionsRef, calcMaxHeight } = useSelectContext();
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <ul className={S.optionList} ref={optionsRef} style={{ maxHeight: calcMaxHeight() }}>
+      {options.map((option) => (
+        <li key={option.label}>
+          <button className={S.option} onClick={() => { handleOptionClick(option); }} type='button'>
+            {type === 'textIcon' && option.icon}
+            {(type === 'userList' || type === 'userListDesc') &&
+              (option.profileUrl ? (
+                <img alt={option.label} className={S.optionProfileImg} src={option.profileUrl} />
+              ) : (
+                <div className={S.optionProfileEmpty}>
+                  <IconUser />
+                </div>
+              ))}
+
+            <div>
+              <p>{option.label}</p>
+              {(type === 'textDesc' || type === 'userListDesc') && <p className={S.optionDesc}>{option.description}</p>}
+            </div>
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+SelectMenu.displayName = 'Select.Menu';
+
+const Select = {
+  Root: SelectRoot,
+  Trigger: SelectTrigger,
+  TriggerContent: SelectTriggerContent,
+  Menu: SelectMenu,
+};
 
 export default Select;

--- a/packages/ui/Input/deprecated/Select.tsx
+++ b/packages/ui/Input/deprecated/Select.tsx
@@ -21,6 +21,7 @@ interface SelectProps<T> {
 }
 
 /**
+ * @deprecated
  * Select 컴포넌트는 더 이상 권장되지 않지만 계속 사용할 수 있습니다.
  * 새로운 `SelectV2` 컴포넌트 사용을 권장합니다.
  */

--- a/packages/ui/Input/deprecated/Select.tsx
+++ b/packages/ui/Input/deprecated/Select.tsx
@@ -1,0 +1,139 @@
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { IconChevronDown, IconUser } from '@sopt-makers/icons';
+import * as S from '../style.css';
+
+export interface Option<T> {
+  label: string;
+  value: T;
+  description?: string;
+  icon?: React.ReactNode;
+  profileUrl?: string;
+}
+
+interface SelectProps<T> {
+  className?: string;
+  placeholder?: string;
+  type: 'text' | 'textDesc' | 'textIcon' | 'userList' | 'userListDesc';
+  options: Option<T>[];
+  visibleOptions?: number;
+  defaultValue?: Option<T>;
+  onChange: (value: T) => void;
+}
+
+/**
+ * Select 컴포넌트는 더 이상 권장되지 않지만 계속 사용할 수 있습니다.
+ * 새로운 `SelectV2` 컴포넌트 사용을 권장합니다.
+ */
+function Select<T extends string | number | boolean>(props: SelectProps<T>) {
+  const { className, placeholder, type, options, visibleOptions = 5, defaultValue, onChange } = props;
+
+  const optionsRef = useRef<HTMLUListElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  const [selected, setSelected] = useState<Option<T> | null>(defaultValue ?? null);
+  const [open, setOpen] = useState(false);
+
+  const handleToggleOpen = useCallback(() => {
+    setOpen((prev) => !prev);
+  }, []);
+
+  const handleToggleClose = useCallback(() => {
+    setOpen(false);
+  }, []);
+
+  const calcMaxHeight = useCallback(() => {
+    const getOptionHeight = () => {
+      switch (type) {
+        case 'text':
+        case 'textIcon':
+          return 42;
+        case 'textDesc':
+        case 'userListDesc':
+          return 62;
+        case 'userList':
+          return 48;
+      }
+    };
+    const gapHeight = 6;
+    const paddingHeight = 8;
+
+    return getOptionHeight() * visibleOptions + gapHeight * (visibleOptions - 1) + paddingHeight * 2;
+  }, [visibleOptions, type]);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        optionsRef.current &&
+        !optionsRef.current.contains(event.target as Node) &&
+        buttonRef.current &&
+        !buttonRef.current.contains(event.target as Node)
+      ) {
+        handleToggleClose();
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [handleToggleClose]);
+
+  const handleOptionClick = (value: Option<T>) => {
+    setSelected(value);
+    onChange(value.value); // value 자체가 아닌 value.value를 onChange에 전달
+    handleToggleClose();
+  };
+
+  const selectedLabel = selected ? options.find((option) => option.value === selected.value)?.label : placeholder;
+
+  return (
+    <div className={`${S.selectWrap} ${className}`}>
+      <button className={S.select} onClick={handleToggleOpen} ref={buttonRef} type='button'>
+        <p className={!selected ? S.selectPlaceholder : ''}>{selectedLabel}</p>
+        <IconChevronDown
+          style={{
+            width: 20,
+            height: 20,
+            transform: open ? 'rotate(-180deg)' : '',
+            transition: 'all 0.5s',
+          }}
+        />
+      </button>
+
+      {open ? (
+        <ul className={S.optionList} ref={optionsRef} style={{ maxHeight: calcMaxHeight() }}>
+          {options.map((option) => (
+            <li key={option.label}>
+              <button
+                className={S.option}
+                onClick={() => {
+                  handleOptionClick(option); // Option<T> 타입으로 전달
+                }}
+                type='button'
+              >
+                {type === 'textIcon' && option.icon}
+                {(type === 'userList' || type === 'userListDesc') &&
+                  (option.profileUrl ? (
+                    <img alt={option.label} className={S.optionProfileImg} src={option.profileUrl} />
+                  ) : (
+                    <div className={S.optionProfileEmpty}>
+                      <IconUser />
+                    </div>
+                  ))}
+
+                <div>
+                  <p>{option.label}</p>
+                  {(type === 'textDesc' || type === 'userListDesc') && (
+                    <p className={S.optionDesc}>{option.description}</p>
+                  )}
+                </div>
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+}
+
+export default Select;

--- a/packages/ui/Input/index.tsx
+++ b/packages/ui/Input/index.tsx
@@ -1,5 +1,10 @@
+// 현행 컴포넌트
+
 export { default as TextField } from './TextField';
 export { default as TextArea } from './TextArea';
 export { default as SearchField } from './SearchField';
-export { default as Select } from './Select';
+export { default as SelectV2 } from './Select';
 export { default as UserMention } from './UserMention';
+
+// deprecated 컴포넌트
+export { default as Select } from './deprecated/Select';

--- a/packages/ui/Input/style.css.ts
+++ b/packages/ui/Input/style.css.ts
@@ -1,71 +1,71 @@
-import { globalStyle, style, keyframes } from "@vanilla-extract/css";
-import theme from "../theme.css";
+import { globalStyle, style, keyframes } from '@vanilla-extract/css';
+import theme from '../theme.css';
 
 const fadeIn = keyframes({
-  "0%": { opacity: 0, transform: "translateY(0)" },
-  "100%": { opacity: 1, transform: "translateY(10px)" },
+  '0%': { opacity: 0, transform: 'translateY(0)' },
+  '100%': { opacity: 1, transform: 'translateY(10px)' },
 });
 
 export const label = style({
   ...theme.fontsObject.LABEL_3_14_SB,
-  display: "flex",
-  flexDirection: "column",
-  textAlign: "left",
+  display: 'flex',
+  flexDirection: 'column',
+  textAlign: 'left',
   color: theme.colors.white,
 });
 
 export const input = style({
   ...theme.fontsObject.BODY_2_16_M,
-  background: theme.colors.gray800,
-  border: "1px solid transparent",
-  borderRadius: "10px",
-  width: "100%",
-  height: "48px",
-  padding: "10px 16px",
-  color: theme.colors.white,
-  boxSizing: "border-box",
+  'background': theme.colors.gray800,
+  'border': '1px solid transparent',
+  'borderRadius': '10px',
+  'width': '100%',
+  'height': '48px',
+  'padding': '10px 16px',
+  'color': theme.colors.white,
+  'boxSizing': 'border-box',
 
-  "::placeholder": {
+  '::placeholder': {
     color: theme.colors.gray300,
   },
-  ":focus": {
+  ':focus': {
     border: `1px solid ${theme.colors.gray200}`,
-    outline: "none",
+    outline: 'none',
   },
-  ":disabled": {
+  ':disabled': {
     color: theme.colors.gray500,
   },
-  ":read-only": {
-    cursor: "default",
+  ':read-only': {
+    cursor: 'default',
   },
 });
 
 export const textarea = style({
-  resize: "none",
-  paddingRight: 0,
-  display: "block",
+  'resize': 'none',
+  'paddingRight': 0,
+  'display': 'block',
 
-  "::-webkit-scrollbar": {
-    width: "48px",
+  '::-webkit-scrollbar': {
+    width: '48px',
   },
-  "::-webkit-scrollbar-thumb": {
+  '::-webkit-scrollbar-thumb': {
     backgroundColor: theme.colors.gray500,
-    backgroundClip: "padding-box",
-    border: "4px solid transparent",
+    backgroundClip: 'padding-box',
+    border: '4px solid transparent',
     boxShadow: `inset -36px 0 0 ${theme.colors.gray800}`,
-    borderRadius: "6px",
+    borderRadius: '6px',
   },
-  "::-webkit-scrollbar-track": {
-    backgroundColor: "transparent",
+  '::-webkit-scrollbar-track': {
+    backgroundColor: 'transparent',
   },
 });
 
 export const searchField = style({
-  paddingRight: "48px",
+  paddingRight: '48px',
 });
 
 export const inputWrap = style({
-  textAlign: "left",
+  textAlign: 'left',
 });
 
 export const inputError = style({
@@ -73,27 +73,27 @@ export const inputError = style({
 });
 
 export const inputBottom = style({
-  marginTop: "8px",
-  display: "flex",
-  justifyContent: "space-between",
-  alignItems: "center",
+  marginTop: '8px',
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
 });
 
 export const required = style({
   color: theme.colors.secondary,
-  marginLeft: "4px",
+  marginLeft: '4px',
 });
 
 export const description = style({
   ...theme.fontsObject.LABEL_4_12_SB,
   color: theme.colors.gray300,
-  marginBottom: "8px",
+  marginBottom: '8px',
 });
 
 export const errorMessage = style({
-  display: "flex",
-  alignItems: "center",
-  gap: "4px",
+  display: 'flex',
+  alignItems: 'center',
+  gap: '4px',
   color: theme.colors.error,
   ...theme.fontsObject.LABEL_4_12_SB,
 });
@@ -108,42 +108,42 @@ export const maxCount = style({
 });
 
 export const submitButton = style({
-  background: "none",
-  border: "none",
-  width: "48px",
-  height: "48px",
-  position: "absolute",
-  right: 0,
-  ":hover": {
-    cursor: "pointer",
+  'background': 'none',
+  'border': 'none',
+  'width': '48px',
+  'height': '48px',
+  'position': 'absolute',
+  'right': 0,
+  ':hover': {
+    cursor: 'pointer',
   },
-  ":disabled": {
-    cursor: "not-allowed",
+  ':disabled': {
+    cursor: 'not-allowed',
   },
 });
 
 export const selectWrap = style({
-  position: "relative",
-  display: "inline-block",
+  position: 'relative',
+  display: 'inline-block',
 });
 
 export const select = style({
   ...theme.fontsObject.BODY_2_16_M,
-  color: theme.colors.white,
-  width: "160px",
-  height: "48px",
-  borderRadius: "10px",
-  background: theme.colors.gray800,
-  border: "1px solid transparent",
-  padding: "11px 16px",
-  display: "flex",
-  justifyContent: "space-between",
-  alignItems: "center",
-  gap: "12px",
-  cursor: "pointer",
-  transition: "border 0.2s",
+  'color': theme.colors.white,
+  'width': '160px',
+  'height': '48px',
+  'borderRadius': '10px',
+  'background': theme.colors.gray800,
+  'border': '1px solid transparent',
+  'padding': '11px 16px',
+  'display': 'flex',
+  'justifyContent': 'space-between',
+  'alignItems': 'center',
+  'gap': '12px',
+  'cursor': 'pointer',
+  'transition': 'border 0.2s',
 
-  ":focus": {
+  ':focus': {
     border: `1px solid ${theme.colors.gray200}`,
   },
 });
@@ -153,50 +153,50 @@ export const selectPlaceholder = style({
 });
 
 export const optionList = style({
-  position: "absolute",
-  display: "flex",
-  flexDirection: "column",
-  width: "max-content",
-  gap: "6px",
-  padding: "8px",
-  borderRadius: "13px",
-  minWidth: "160px",
-  background: theme.colors.gray800,
-  overflow: "scroll",
-  transformOrigin: "top",
-  animation: `${fadeIn} 0.5s forwards`,
-  overflowX: "hidden",
+  'position': 'absolute',
+  'display': 'flex',
+  'flexDirection': 'column',
+  'width': 'max-content',
+  'gap': '6px',
+  'padding': '8px',
+  'borderRadius': '13px',
+  'minWidth': '160px',
+  'background': theme.colors.gray800,
+  'overflow': 'scroll',
+  'transformOrigin': 'top',
+  'animation': `${fadeIn} 0.5s forwards`,
+  'overflowX': 'hidden',
 
-  "::-webkit-scrollbar": {
-    width: "16px",
+  '::-webkit-scrollbar': {
+    width: '16px',
   },
-  "::-webkit-scrollbar-thumb": {
+  '::-webkit-scrollbar-thumb': {
     background: theme.colors.gray500,
-    backgroundClip: "padding-box",
-    border: "4px solid transparent",
+    backgroundClip: 'padding-box',
+    border: '4px solid transparent',
     boxShadow: `inset -3px 0 0 ${theme.colors.gray800}`,
-    borderRadius: "8px",
+    borderRadius: '8px',
   },
 });
 
 export const option = style({
   ...theme.fontsObject.BODY_2_16_M,
-  border: "none",
-  background: "none",
-  borderRadius: "8px",
-  color: theme.colors.gray10,
-  padding: "8px 12px",
-  width: "100%",
-  textAlign: "left",
-  cursor: "pointer",
-  display: "flex",
-  alignItems: "center",
-  gap: "10px",
+  'border': 'none',
+  'background': 'none',
+  'borderRadius': '8px',
+  'color': theme.colors.gray10,
+  'padding': '8px 12px',
+  'width': '100%',
+  'textAlign': 'left',
+  'cursor': 'pointer',
+  'display': 'flex',
+  'alignItems': 'center',
+  'gap': '10px',
 
-  ":hover": {
+  ':hover': {
     background: theme.colors.gray700,
   },
-  ":active": {
+  ':active': {
     background: theme.colors.gray600,
   },
 });
@@ -204,25 +204,25 @@ export const option = style({
 export const optionDesc = style({
   ...theme.fontsObject.BODY_4_13_R,
   color: theme.colors.gray100,
-  overflow: "hidden",
-  whiteSpace: "nowrap",
-  textOverflow: "ellipsis",
+  overflow: 'hidden',
+  whiteSpace: 'nowrap',
+  textOverflow: 'ellipsis',
 });
 
 export const optionProfileImg = style({
-  width: "32px",
-  height: "32px",
-  borderRadius: "50%",
+  width: '32px',
+  height: '32px',
+  borderRadius: '50%',
 });
 
 export const optionProfileEmpty = style({
-  width: "32px",
-  height: "32px",
-  borderRadius: "50%",
+  width: '32px',
+  height: '32px',
+  borderRadius: '50%',
   background: theme.colors.gray700,
-  display: "flex",
-  justifyContent: "center",
-  alignItems: "center",
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
 });
 
 export const userMention = style({
@@ -231,10 +231,10 @@ export const userMention = style({
 });
 
 export const userMentionItem = style({
-  ":hover": {
+  ':hover': {
     background: theme.colors.gray800,
   },
-  ":active": {
+  ':active': {
     background: theme.colors.gray700,
   },
 });
@@ -244,15 +244,23 @@ globalStyle(`${inputWrap} > ${description}`, {
 });
 
 globalStyle(`${label} > span`, {
-  marginBottom: "8px",
+  marginBottom: '8px',
 });
 
 globalStyle(`${option} > svg`, {
-  width: "16px",
-  height: "16px",
+  width: '16px',
+  height: '16px',
 });
 
 globalStyle(`${optionProfileEmpty} > svg`, {
-  width: "20px",
-  height: "20px",
+  width: '20px',
+  height: '20px',
+});
+
+export const buttonWithNoStyle = style({
+  background: 'none',
+  border: 'none',
+  padding: 0,
+  margin: 0,
+  cursor: 'pointer',
 });

--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -2,16 +2,16 @@ export * from './cssVariables';
 
 // component exports
 export { default as Button } from './Button';
-export { CheckBox, Toggle, Radio } from "./Control";
+export { CheckBox, Toggle, Radio } from './Control';
 export { Dialog, DialogContext, DialogProvider, useDialog } from './Dialog';
 export type { DialogOptionType } from './Dialog';
 export { ToastProvider, useToast, Toast } from './Toast';
 export type { ToastOptionType } from './Toast';
-export { TextField, TextArea, SearchField, Select, UserMention } from "./Input";
-export { default as Tag } from "./Tag";
+export { TextField, TextArea, SearchField, SelectV2, Select, UserMention } from './Input';
+export { default as Tag } from './Tag';
 export { default as Chip } from './Chip';
-export { default as Callout } from "./Callout";
-export { default as Tab } from "./Tab";
+export { default as Callout } from './Callout';
+export { default as Tab } from './Tab';
 
 // test component
 export { default as Test } from './Test';


### PR DESCRIPTION
## 변경사항

<!-- 어떤 변경사항이 있는지, PR 타이틀과 동일하다면 Skip -->


radix-ui의 컴포넌트 구성 방식을 참고하여 Select 컴포넌트를 리팩토링 했어요.
https://github.com/radix-ui/themes/blob/main/packages/radix-ui-themes/src/components/dropdown-menu.tsx

변경된 Select의 구성은 다음과 같아요
- Select.Root (하위 서브컴포넌트들에게 context를 내려줌)
- Select.Trigger (Select.Menu를 열수있는 Trigger)
- Select.TriggerContent (Select.Trigger의 미리 정의된 UI)
- Select.Menu (드롭다운을 감싸는 UI)
- Select.MenuItem (드롭다운 요소 하나의 UI)

> 기존의 Select 컴포넌트는 버튼 / 하단 dropdown이 하나의 컴포넌트로 이루어져 있어서 원하는 부분만 사용하기 어려웠어요.
> 그래서 합성컴포넌트 방식으로, 각 필요한 요소를 조합해서 사용할 수 있도록 했어요.

> 기존의 컴포넌트는 dropdown에 쓰일 데이터인 options를 prop으로 받고있었어요, 이 prop은 삭제 후 사용자가 직접 map과 같은 함수를 사용하여 dropdown의 요소들을 렌더링할 수있게 했고, 이 외의 동작은 동일하게 구성했어요.  - `Menu / MenuItem 으로 드롭다운 분리`


### Select.Root
---
Select.Root에서 사용자는 prop으로 데이터를 전달해주게돼요. Select.Root는 전달받은 데이터를 바탕으로 정의된 함수 상태들을 자식요소에게 내려주는 역할을 해요. (`context`를 사용했습니다.)

- 서브 컴포넌트들은 Select의 기본동작에 따른 상태에 종속되기 때문에, 서브컴포넌트가 Select.Root 밖에서 쓰일경우 에러 처리를 해놨어요

```javascript
// useSelectContext: Select 컴포넌트 외부에서 서브 컴포넌트들이 사용됐을 때 에러 처리
function useSelectContext<T>() {
  const context = useContext(SelectContext);
  if (Object.keys(context).length === 0) {
    throw new Error('Select 컴포넌트는 Select.Root 내에서 사용되어야 합니다.');
  }
  return context as SelectContextProps<T>;
}
```

```javascript
function SelectRoot<T extends string | number | boolean>(props: SelectProps<T>) {
  const { children, onChange, defaultValue, type, visibleOptions = 5, className } = props;

  const buttonRef = useRef<HTMLButtonElement>(null);
  const optionsRef = useRef<HTMLUListElement>(null);

  const [selected, setSelected] = useState<Option<T> | null>(defaultValue ?? null);
  const [open, setOpen] = useState(false);

  ....

    const contextValue: SelectContextProps<T> = {
    open,
    setOpen,
    selected,
  ....
  }

  return (
    <SelectContext.Provider value={contextValue}>
      <div className={`${S.selectWrap} ${className}`}>{children}</div>
    </SelectContext.Provider>
  );
 }
```

<br/>

### Select.Trigger
---
Select.Trigger는 Select.Menu를 열고 닫는 트리거의 역할만을 해요.
`children`을 받아 직접 custom한 UI도 trigger 역할을 할 수 있게 하여 유연성을 높였어요.


```javascript
// Select.Trigger 컴포넌트: 메뉴를 열고 닫는 trigger
interface SelectTriggerProps {
  children: React.ReactNode;
}

function SelectTrigger({ children }: SelectTriggerProps) {
  const { open, setOpen, buttonRef } = useSelectContext();

  const handleClick = () => {
    setOpen(!open);
  };

  return (
    <button className={S.buttonWithNoStyle} onClick={handleClick} ref={buttonRef} type='button'>
      {children}
    </button>
  );
}
```

<br/>

### Select.TriggerContent
---
Select.TriggerContent는 Select.Trigger에 쓰이는 단순 기존 UI에요. 편의를 위해 만들었어요.
<img width="209" alt="image" src="https://github.com/user-attachments/assets/3cd23bc5-08a7-48e1-a231-da81a6a97c20">

```javascript
function SelectTriggerContent({ className, placeholder }: SelectTriggerContentProps) {
  const { open, selected } = useSelectContext();

  const selectedLabel = selected ? selected.label : placeholder;

  return (
    <div className={`${S.select} ${className ? className : ''}`}>
      <p className={!selected ? S.selectPlaceholder : ''}>{selectedLabel}</p>
      <IconChevronDown
        style={{
          width: 20,
          height: 20,
          transform: open ? 'rotate(-180deg)' : '',
          transition: 'all 0.3s ease',
        }}
      />
    </div>
  );
}
```
<br/>

### Select.Menu
---
드롭다운 메뉴를 감싸주는 UI

```javascript
function SelectMenu({ children }: SelectMenuProps) {
  const { open, optionsRef, calcMaxHeight } = useSelectContext();

  if (!open) {
    return null;
  }

  return (
    <ul className={S.optionList} ref={optionsRef} style={{ maxHeight: calcMaxHeight() }}>
      {children}
    </ul>
  );
}
```

- 기존 로직을 동일하게 사용했어요, 추후에 로직 정리가 필요해보여요.

</br>

### Select.MenuItem
---
드롭다운 메뉴를 안에서 사용할 Item 요소에요.

- 기존 컴포넌트는 `dropdown 아이템 하나`를 클릭하면 `onChange 함수`를 통해서 현재 선택된 option을 변경해주게 되어있었어요, 즉 onClick함수에 현재 선택된 메뉴를 변경하는 기능만 한정되어있었죠.

<img width="362" alt="image" src="https://github.com/user-attachments/assets/c4acdf50-9613-4e6b-850f-32e24da7216e">

위와 같은 요구사항을 반영하려면, Item 요소에 조건부로 onClick 함수를 받아, 현재 선택된 option 을 변경하는 기능 외 추가적으로 커스텀 로직을 동작할수 있게 해야한다고 생각했어요. 그래서 추가 동작을 하는 onClick 을 조건부로 Select.MenuItem prop에 추가했어요.

```javascript

function SelectMenuItem<T>({ option, onClick }: SelectMenuItemProps<T>) {
  const { open, type, handleOptionClick } = useSelectContext();

  const handleClick = () => {
    handleOptionClick(option);

    if (onClick) {
      onClick();
    }
  };

  if (!open) {
    return null;
  }

  return (
    <li>
      <button className={S.option} onClick={handleClick} type='button'>
        {type === 'textIcon' && option.icon}
        {(type === 'userList' || type === 'userListDesc') &&
          (option.profileUrl ? (
            <img alt={option.label} className={S.optionProfileImg} src={option.profileUrl} />
          ) : (
            <div className={S.optionProfileEmpty}>
              <IconUser />
            </div>
          ))}

        <div>
          <p>{option.label}</p>
          {(type === 'textDesc' || type === 'userListDesc') && <p className={S.optionDesc}>{option.description}</p>}
        </div>
      </button>
    </li>
  );
}
```

<br/>

> 사용 예시
Select.Root에 데이터를 전달하고, Root아래 하위 컴포넌트를 구성해주어 사용하면 됩니다.
- onChange 함수는 조건부로 받을 수 있습니다. onChange가 필요 없는 경우도 있을거라고 판단했어요. ( Select.MenuItem의 onClick 함수 만을 활용하는 경우)
- Select.MenuItem 컴포넌트에 조건부로 onClick 함수를 사용할 수 있으며, key 값은 따로 등록해주어야합니다.

```javascript
//Select.TriggerContent를 사용(O)

      <Select.Root visibleOptions={2} onChange={handleChange} type='text'>
        <Select.Trigger>
          <Select.TriggerContent placeholder='새로운 Select' />
        </Select.Trigger>
        <Select.Menu>
          {options.map((option) => (
            <Select.MenuItem
              key={option.value}
              option={option}
              onClick={() => {
                console.log('custom logic');
              }}
            />
          ))}
        </Select.Menu>
      </Select.Root>
```

```javascript
//Select.TriggerContent를 사용(X)

      <Select.Root visibleOptions={2} onChange={handleChange} type='text'>
        <Select.Trigger>
         <p>Custom UI</p>
        </Select.Trigger>
        <Select.Menu>
          {options.map((option) => (
            <Select.MenuItem
              key={option.value}
              option={option}
              onClick={() => {
                console.log('custom logic');
              }}
            />
          ))}
        </Select.Menu>
      </Select.Root>
```

<br/>

- 리뷰 후에 Story랑 Changesets 추가하겠습니다~!

### 고민점 
- trigger 컴포넌트 생성, 단순히 dropdown과 상단의 선택된 메뉴를 보여주는 UI(?)만을 분리한다면, trigger를 위한 동작을 위해 라이브러리를 사용하는 사용자가 함수 등을 정의해주는 번거로움이 있을거라고 생각했어요. 그래서 trigger 컴포넌트를 분리하였고, children으로 UI를 받아 headless하게 열고 닫는 동작을 할 수 있게 했습니다.

- Menu 컴포넌트, 보통 UI 라이브러리들의 리스트 컴포넌트를 보면, 리스트를 감싸는 wrapper, 리스트 요소 하나에 해당하는 Item 컴포넌트를 따로 분리하게 되어있어요. 이런 구성은 wrapper와 item의 ui나 레이아웃이 변경되었을 때 유연하게 대처할수 있다는 장점이 있을것 같습니다. 그렇지만 기존 컴포넌트와 사용방식에 차이가 나게되는데요, 이에 대한 의견이 궁금해요.

- 상태와 함수, 현재는 상태와 함수는 거의 정리하지 않았어요. 리소스 상, 기존 로직을 유지하고 상태와 함수 개선이 꼭 필요한 부분이 생겼을 때 정리하는게 좋을것 같다는 생각이 들었어요. 

<br>

- Root 컴포넌트 밖에서 서브 컴포넌트를 사용했을 경우
<img width="306" alt="image" src="https://github.com/user-attachments/assets/85f4c085-50db-440c-b43d-cba8f8c5801d">
<img width="613" alt="image" src="https://github.com/user-attachments/assets/a3f85677-0674-4c07-936e-98ae6db67ee8">

<br>

-

https://github.com/user-attachments/assets/8c190b2e-5b9f-416a-ad2b-c274fb1e2066


https://github.com/user-attachments/assets/6dff83b3-fb65-4077-9f4e-2cb5428153b2



## 링크

<!-- 제플린 화면 링크 또는 관련된 대화가 이루어진 slack, height, figma 링크를 첨부. -->

https://sopt-makers.slack.com/lists/T040QGZF77H/F07LCJ586TS?record_id=Rec07MHJ4LQ9J

## 시급한 정도

🏃‍♂️ 보통 : 최대한 빠르게 리뷰 부탁드립니다.

<!-- ⚠︎ 긴급 : 선 어프루브 후 리뷰를 부탁드립니다. (리뷰는 추후 반영)  -->
<!-- 🐢 천천히 : 급하지 않습니다. -->

## 기타 사항

- css 변경사항은 단순히 button style만 하나 추가주었습니다.

```javascript
export const buttonWithNoStyle = style({
  background: 'none',
  border: 'none',
  padding: 0,
  margin: 0,
  cursor: 'pointer',
});
```

- Select의 구조가 변경되어, 사용방식에 대한 문서 정리가 필요할것 같습니다...!

<!-- 변경사항이 큰 경우 집중해야 할 부분, 또는 불안해서 봐주었으면 하는 부분 등 -->

<!-- ### AS-IS -->

<!-- ### TO-BE -->
