### PR TITLE
feat(Select): 서브 컴포넌트 사용 케이스를 나누어 스토리북 작성

### DIFF
--- a/.changeset/fluffy-plants-double.md
+++ b/.changeset/fluffy-plants-double.md
@@ -1,0 +1,5 @@
+---
+'docs': patch
+---
+
+SelectV2 스토리북 작성

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -16,7 +16,7 @@
     "@sopt-makers/colors": "^3.0.1",
     "@sopt-makers/fonts": "^2.0.1",
     "@sopt-makers/icons": "^1.0.5",
-    "@sopt-makers/ui": "^2.2.0"
+    "@sopt-makers/ui": "^2.3.0"
   },
   "devDependencies": {
     "@storybook/addon-essentials": "^7.6.3",

--- a/apps/docs/src/stories/Select.stories.tsx
+++ b/apps/docs/src/stories/Select.stories.tsx
@@ -1,70 +1,84 @@
-import type { Meta, StoryObj } from "@storybook/react";
-import { Select } from "@sopt-makers/ui";
-import { IconSend } from "@sopt-makers/icons";
+import type { Meta, StoryObj } from '@storybook/react';
+import { Select } from '@sopt-makers/ui';
+import { IconSend } from '@sopt-makers/icons';
 import { fn } from '@storybook/test';
 
-const selectOptions = [{
-  label: 'All',
-  value: '',
-  description: 'select all',
-  icon: <IconSend />,
-}, {
-  label: 'Option 1',
-  value: 'option1',
-  description: 'Description 1',
-  icon: <IconSend />,
-}, {
-  label: 'Option 2',
-  value: 'option2',
-  description: 'Description 2',
-  icon: <IconSend />,
-}, {
-  label: 'Option 3',
-  value: 'option3',
-  description: 'Description 3',
-  icon: <IconSend />,
-}, {
-  label: 'Option 4',
-  value: 'option4',
-  description: 'Description 4',
-  icon: <IconSend />,
-}, {
-  label: 'Option 5',
-  value: 'option5',
-  description: 'Description 5',
-  icon: <IconSend />,
-}];
+const selectOptions = [
+  {
+    label: 'All',
+    value: '',
+    description: 'select all',
+    icon: <IconSend />,
+  },
+  {
+    label: 'Option 1',
+    value: 'option1',
+    description: 'Description 1',
+    icon: <IconSend />,
+  },
+  {
+    label: 'Option 2',
+    value: 'option2',
+    description: 'Description 2',
+    icon: <IconSend />,
+  },
+  {
+    label: 'Option 3',
+    value: 'option3',
+    description: 'Description 3',
+    icon: <IconSend />,
+  },
+  {
+    label: 'Option 4',
+    value: 'option4',
+    description: 'Description 4',
+    icon: <IconSend />,
+  },
+  {
+    label: 'Option 5',
+    value: 'option5',
+    description: 'Description 5',
+    icon: <IconSend />,
+  },
+];
 
-const userOptions = [{
-  label: 'Person 1',
-  value: 1,
-  description: 'person 1 desc',
-}, {
-  label: 'Person 2',
-  value: 2,
-  description: 'person 2 desc',
-}, {
-  label: 'Person 3',
-  value: 3,
-  description: 'person 3 desc',
-}, {
-  label: 'Person 4',
-  value: 4,
-  description: 'person 4 desc',
-}, {
-  label: 'Person 5',
-  value: 5,
-  description: 'person 5 desc',
-}, {
-  label: 'Person 6',
-  value: 6,
-  description: 'person 6 desc',
-}];
+const userOptions = [
+  {
+    label: 'Person 1',
+    value: 1,
+    description: 'person 1 desc',
+  },
+  {
+    label: 'Person 2',
+    value: 2,
+    description: 'person 2 desc',
+  },
+  {
+    label: 'Person 3',
+    value: 3,
+    description: 'person 3 desc',
+  },
+  {
+    label: 'Person 4',
+    value: 4,
+    description: 'person 4 desc',
+  },
+  {
+    label: 'Person 5',
+    value: 5,
+    description: 'person 5 desc',
+  },
+  {
+    label: 'Person 6',
+    value: 6,
+    description: 'person 6 desc',
+  },
+];
 
 const meta = {
-  title: "Components/Input/Select",
+  title: 'Components/Input/deprecated/Select',
   component: Select,
-  tags: ["autodocs"],
+  tags: ['autodocs'],
   args: {
     placeholder: 'Placeholder',
     visibleOptions: 3,
@@ -74,7 +88,7 @@ const meta = {
     defaultValue: { control: 'select', options: ['', 'option1', 'option2', 'option3', 'option4', 'option5'] },
     placeholder: { control: 'text' },
     visibleOptions: { control: 'number' },
-  }
+  },
 } as Meta<typeof Select>;
 
 export default meta;
@@ -86,7 +100,7 @@ export const Text: StoryObj = {
   },
   argTypes: {
     type: { control: 'radio', options: ['text', 'textDesc', 'textIcon'] },
-  }
+  },
 };
 
 export const TextDesc: StoryObj = {
@@ -96,7 +110,7 @@ export const TextDesc: StoryObj = {
   },
   argTypes: {
     type: { control: 'radio', options: ['text', 'textDesc', 'textIcon'] },
-  }
+  },
 };
 
 export const TextIcon: StoryObj = {
@@ -106,7 +120,7 @@ export const TextIcon: StoryObj = {
   },
   argTypes: {
     type: { control: 'radio', options: ['text', 'textDesc', 'textIcon'] },
-  }
+  },
 };
 
 export const UserList: StoryObj = {
@@ -116,7 +130,7 @@ export const UserList: StoryObj = {
   },
   argTypes: {
     type: { control: 'radio', options: ['userList', 'userListDesc'] },
-  }
+  },
 };
 
 export const UserListDesc: StoryObj = {
@@ -126,5 +140,5 @@ export const UserListDesc: StoryObj = {
   },
   argTypes: {
     type: { control: 'radio', options: ['userList', 'userListDesc'] },
-  }
+  },
 };

--- a/apps/docs/src/stories/SelectV2NoTriggerContent.stories.tsx
+++ b/apps/docs/src/stories/SelectV2NoTriggerContent.stories.tsx
@@ -82,7 +82,6 @@ export const TextDesc: StoryObj<typeof SelectV2.Root> = {
         </div>
       </SelectV2.Trigger>
       <SelectV2.Menu>
-        <IconSend />
         {selectOptions.map((option) => (
           <SelectV2.MenuItem key={option.value} option={option} />
         ))}

--- a/apps/docs/src/stories/SelectV2NoTriggerContent.stories.tsx
+++ b/apps/docs/src/stories/SelectV2NoTriggerContent.stories.tsx
@@ -1,0 +1,171 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { SelectV2 } from '@sopt-makers/ui';
+import { IconSend, IconDotsVertical } from '@sopt-makers/icons';
+import { fn } from '@storybook/test';
+
+const selectOptions = [
+  {
+    label: '수정',
+    value: '',
+    description: '수정',
+    icon: <IconSend />,
+  },
+  {
+    label: '삭제',
+    value: 'option1',
+    description: '삭제',
+    icon: <IconSend />,
+  },
+];
+
+const userOptions = [
+  {
+    label: '수정',
+    value: 1,
+    description: '수정',
+  },
+  {
+    label: '삭제',
+    value: 2,
+    description: '삭제',
+  },
+];
+
+const style = { width: 24, height: 24, color: 'white' };
+
+const meta: Meta<typeof SelectV2.Root> = {
+  title: 'Components/Input/SelectV2/NoTriggerContent',
+  component: SelectV2.Root,
+  tags: ['autodocs'],
+  args: {
+    visibleOptions: 3,
+    onChange: fn(),
+  },
+  argTypes: {
+    defaultValue: { control: 'select', options: ['', 'option1', 'option2', 'option3', 'option4', 'option5'] },
+    visibleOptions: { control: 'number' },
+  },
+};
+
+export default meta;
+
+export const Text: StoryObj<typeof SelectV2.Root> = {
+  render: (args) => (
+    <SelectV2.Root {...args}>
+      <SelectV2.Trigger>
+        <div>
+          <IconDotsVertical style={style} />
+        </div>
+      </SelectV2.Trigger>
+      <SelectV2.Menu>
+        {selectOptions.map((option) => (
+          <SelectV2.MenuItem key={option.value} option={option} />
+        ))}
+      </SelectV2.Menu>
+    </SelectV2.Root>
+  ),
+  args: {
+    type: 'text',
+    visibleOptions: 3,
+  },
+  argTypes: {
+    type: { control: 'radio', options: ['text', 'textDesc', 'textIcon'] },
+  },
+};
+
+export const TextDesc: StoryObj<typeof SelectV2.Root> = {
+  render: (args) => (
+    <SelectV2.Root {...args}>
+      <SelectV2.Trigger>
+        <div>
+          <IconDotsVertical style={style} />
+        </div>
+      </SelectV2.Trigger>
+      <SelectV2.Menu>
+        <IconSend />
+        {selectOptions.map((option) => (
+          <SelectV2.MenuItem key={option.value} option={option} />
+        ))}
+      </SelectV2.Menu>
+    </SelectV2.Root>
+  ),
+  args: {
+    type: 'textDesc',
+    visibleOptions: 3,
+  },
+  argTypes: {
+    type: { control: 'radio', options: ['text', 'textDesc', 'textIcon'] },
+  },
+};
+
+export const TextIcon: StoryObj<typeof SelectV2.Root> = {
+  render: (args) => (
+    <SelectV2.Root {...args}>
+      <SelectV2.Trigger>
+        <div>
+          <IconDotsVertical style={style} />
+        </div>
+      </SelectV2.Trigger>
+      <SelectV2.Menu>
+        {selectOptions.map((option) => (
+          <SelectV2.MenuItem key={option.value} option={option} />
+        ))}
+      </SelectV2.Menu>
+    </SelectV2.Root>
+  ),
+  args: {
+    type: 'textIcon',
+    visibleOptions: 3,
+  },
+  argTypes: {
+    type: { control: 'radio', options: ['text', 'textDesc', 'textIcon'] },
+  },
+};
+
+export const UserList: StoryObj<typeof SelectV2.Root> = {
+  render: (args) => (
+    <SelectV2.Root {...args}>
+      <SelectV2.Trigger>
+        <div>
+          <IconDotsVertical style={style} />
+        </div>
+      </SelectV2.Trigger>
+      <SelectV2.Menu>
+        {userOptions.map((option) => (
+          <SelectV2.MenuItem key={option.value} option={option} />
+        ))}
+      </SelectV2.Menu>
+    </SelectV2.Root>
+  ),
+  args: {
+    type: 'userList',
+    visibleOptions: 3,
+  },
+  argTypes: {
+    type: { control: 'radio', options: ['userList', 'userListDesc'] },
+  },
+};
+
+export const UserListDesc: StoryObj<typeof SelectV2.Root> = {
+  render: (args) => (
+    <SelectV2.Root {...args}>
+      <SelectV2.Trigger>
+        <div>
+          <IconDotsVertical style={style} />
+        </div>
+      </SelectV2.Trigger>
+      <SelectV2.Menu>
+        {userOptions.map((option) => (
+          <SelectV2.MenuItem key={option.value} option={option} />
+        ))}
+      </SelectV2.Menu>
+    </SelectV2.Root>
+  ),
+  args: {
+    type: 'userListDesc',
+    visibleOptions: 3,
+  },
+  argTypes: {
+    type: { control: 'radio', options: ['userList', 'userListDesc'] },
+  },
+};

--- a/apps/docs/src/stories/SelectV2WithTriggerContent.stories.tsx
+++ b/apps/docs/src/stories/SelectV2WithTriggerContent.stories.tsx
@@ -1,0 +1,212 @@
+import { ComponentProps } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { SelectV2 } from '@sopt-makers/ui';
+import { IconSend } from '@sopt-makers/icons';
+import { fn } from '@storybook/test';
+
+interface SelectStoryArgs extends ComponentProps<typeof SelectV2.Root> {
+  placeholder: string;
+}
+
+const selectOptions = [
+  {
+    label: 'All',
+    value: '',
+    description: 'select all',
+    icon: <IconSend />,
+  },
+  {
+    label: 'Option 1',
+    value: 'option1',
+    description: 'Description 1',
+    icon: <IconSend />,
+  },
+  {
+    label: 'Option 2',
+    value: 'option2',
+    description: 'Description 2',
+    icon: <IconSend />,
+  },
+  {
+    label: 'Option 3',
+    value: 'option3',
+    description: 'Description 3',
+    icon: <IconSend />,
+  },
+  {
+    label: 'Option 4',
+    value: 'option4',
+    description: 'Description 4',
+    icon: <IconSend />,
+  },
+  {
+    label: 'Option 5',
+    value: 'option5',
+    description: 'Description 5',
+    icon: <IconSend />,
+  },
+];
+
+const userOptions = [
+  {
+    label: 'Person 1',
+    value: 1,
+    description: 'person 1 desc',
+  },
+  {
+    label: 'Person 2',
+    value: 2,
+    description: 'person 2 desc',
+  },
+  {
+    label: 'Person 3',
+    value: 3,
+    description: 'person 3 desc',
+  },
+  {
+    label: 'Person 4',
+    value: 4,
+    description: 'person 4 desc',
+  },
+  {
+    label: 'Person 5',
+    value: 5,
+    description: 'person 5 desc',
+  },
+  {
+    label: 'Person 6',
+    value: 6,
+    description: 'person 6 desc',
+  },
+];
+
+const meta: Meta<typeof SelectV2.Root> = {
+  title: 'Components/Input/SelectV2/WithTriggerContent',
+  component: SelectV2.Root,
+  tags: ['autodocs'],
+  args: {
+    visibleOptions: 3,
+    onChange: fn(),
+  },
+  argTypes: {
+    defaultValue: { control: 'select', options: ['', 'option1', 'option2', 'option3', 'option4', 'option5'] },
+    visibleOptions: { control: 'number' },
+  },
+};
+
+export default meta;
+
+export const Text: StoryObj<SelectStoryArgs> = {
+  render: ({ placeholder, ...args }) => (
+    <SelectV2.Root {...args}>
+      <SelectV2.Trigger>
+        <SelectV2.TriggerContent placeholder={placeholder} />
+      </SelectV2.Trigger>
+      <SelectV2.Menu>
+        {selectOptions.map((option) => (
+          <SelectV2.MenuItem key={option.value} option={option} />
+        ))}
+      </SelectV2.Menu>
+    </SelectV2.Root>
+  ),
+  args: {
+    type: 'text',
+    visibleOptions: 3,
+    placeholder: 'placeholder',
+  },
+  argTypes: {
+    type: { control: 'radio', options: ['text', 'textDesc', 'textIcon'] },
+  },
+};
+
+export const TextDesc: StoryObj<SelectStoryArgs> = {
+  render: ({ placeholder, ...args }) => (
+    <SelectV2.Root {...args}>
+      <SelectV2.Trigger>
+        <SelectV2.TriggerContent placeholder={placeholder} />
+      </SelectV2.Trigger>
+      <SelectV2.Menu>
+        {selectOptions.map((option) => (
+          <SelectV2.MenuItem key={option.value} option={option} />
+        ))}
+      </SelectV2.Menu>
+    </SelectV2.Root>
+  ),
+  args: {
+    type: 'textDesc',
+    visibleOptions: 3,
+    placeholder: 'placeholder',
+  },
+  argTypes: {
+    type: { control: 'radio', options: ['text', 'textDesc', 'textIcon'] },
+  },
+};
+
+export const TextIcon: StoryObj<SelectStoryArgs> = {
+  render: ({ placeholder, ...args }) => (
+    <SelectV2.Root {...args}>
+      <SelectV2.Trigger>
+        <SelectV2.TriggerContent placeholder={placeholder} />
+      </SelectV2.Trigger>
+      <SelectV2.Menu>
+        {selectOptions.map((option) => (
+          <SelectV2.MenuItem key={option.value} option={option} />
+        ))}
+      </SelectV2.Menu>
+    </SelectV2.Root>
+  ),
+  args: {
+    type: 'textIcon',
+    visibleOptions: 3,
+    placeholder: 'placeholder',
+  },
+  argTypes: {
+    type: { control: 'radio', options: ['text', 'textDesc', 'textIcon'] },
+  },
+};
+
+export const UserList: StoryObj<SelectStoryArgs> = {
+  render: ({ placeholder, ...args }) => (
+    <SelectV2.Root {...args}>
+      <SelectV2.Trigger>
+        <SelectV2.TriggerContent placeholder={placeholder} />
+      </SelectV2.Trigger>
+      <SelectV2.Menu>
+        {userOptions.map((option) => (
+          <SelectV2.MenuItem key={option.value} option={option} />
+        ))}
+      </SelectV2.Menu>
+    </SelectV2.Root>
+  ),
+  args: {
+    type: 'userList',
+    visibleOptions: 3,
+    placeholder: 'placeholder',
+  },
+  argTypes: {
+    type: { control: 'radio', options: ['userList', 'userListDesc'] },
+  },
+};
+
+export const UserListDesc: StoryObj<SelectStoryArgs> = {
+  render: ({ placeholder, ...args }) => (
+    <SelectV2.Root {...args}>
+      <SelectV2.Trigger>
+        <SelectV2.TriggerContent placeholder={placeholder} />
+      </SelectV2.Trigger>
+      <SelectV2.Menu>
+        {userOptions.map((option) => (
+          <SelectV2.MenuItem key={option.value} option={option} />
+        ))}
+      </SelectV2.Menu>
+    </SelectV2.Root>
+  ),
+  args: {
+    type: 'userListDesc',
+    visibleOptions: 3,
+    placeholder: 'placeholder',
+  },
+  argTypes: {
+    type: { control: 'radio', options: ['userList', 'userListDesc'] },
+  },
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,8 +43,8 @@ importers:
         specifier: ^1.0.5
         version: 1.0.5(react@18.3.1)
       '@sopt-makers/ui':
-        specifier: ^2.2.0
-        version: 2.2.0(@types/react-dom@18.3.0)(@types/react@18.3.5)(postcss@8.4.45)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.2)
+        specifier: ^2.3.0
+        version: 2.3.0(@types/react-dom@18.3.0)(@types/react@18.3.5)(postcss@8.4.45)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.2)
     devDependencies:
       '@storybook/addon-essentials':
         specifier: ^7.6.3
@@ -123,7 +123,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^7.2.0
-        version: 7.3.0(postcss@8.4.45)(ts-node@10.9.2(@types/node@20.16.5)(typescript@5.6.2))(typescript@5.6.2)
+        version: 7.3.0(postcss@8.4.45)(ts-node@10.9.2(typescript@5.6.2))(typescript@5.6.2)
       typescript:
         specifier: ^5.2.2
         version: 5.6.2
@@ -138,13 +138,13 @@ importers:
         version: 1.13.4(eslint@8.57.0)
       eslint-plugin-vitest:
         specifier: ^0.5.4
-        version: 0.5.4(@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)(typescript@5.6.2)(vitest@2.0.5(@types/node@20.16.5)(jsdom@25.0.0))
+        version: 0.5.4(@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)(typescript@5.6.2)(vitest@2.0.5)
 
   packages/fonts:
     devDependencies:
       tsup:
         specifier: ^7.2.0
-        version: 7.3.0(postcss@8.4.45)(ts-node@10.9.2(@types/node@20.16.5)(typescript@5.6.2))(typescript@5.6.2)
+        version: 7.3.0(postcss@8.4.45)(ts-node@10.9.2(typescript@5.6.2))(typescript@5.6.2)
       typescript:
         specifier: ^5.2.2
         version: 5.6.2
@@ -163,7 +163,7 @@ importers:
         version: 18.3.5
       tsup:
         specifier: ^7.2.0
-        version: 7.3.0(postcss@8.4.45)(ts-node@10.9.2(@types/node@20.16.5)(typescript@5.6.2))(typescript@5.6.2)
+        version: 7.3.0(postcss@8.4.45)(ts-node@10.9.2(typescript@5.6.2))(typescript@5.6.2)
       typescript:
         specifier: ^5.2.2
         version: 5.6.2
@@ -2324,8 +2324,8 @@ packages:
     peerDependencies:
       react: ^18.2.0
 
-  '@sopt-makers/ui@2.2.0':
-    resolution: {integrity: sha512-9aXqdqbfqLZ0d3gql2nO+tdEDKBGgk9yqmg3KK9RwJ/Nep6UhYVs8WtA5rLgReW7KwzL/UBcVup6DCLiywsheA==}
+  '@sopt-makers/ui@2.3.0':
+    resolution: {integrity: sha512-NGASovJHlEwJB2oKGbo1SJj6zyYklZLK6A5d7L/ykCKW8qfBiR+l+Grm03n4J6ZRYK+9fkmHJz3hc/KiZ7y9OA==}
     peerDependencies:
       react: ^18.2.0
       react-dom: ^18.2.0
@@ -9180,7 +9180,7 @@ snapshots:
     dependencies:
       react: 18.3.1
 
-  '@sopt-makers/ui@2.2.0(@types/react-dom@18.3.0)(@types/react@18.3.5)(postcss@8.4.45)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.2)':
+  '@sopt-makers/ui@2.3.0(@types/react-dom@18.3.0)(@types/react@18.3.5)(postcss@8.4.45)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.2)':
     dependencies:
       '@radix-ui/react-dialog': 1.1.1(@types/react-dom@18.3.0)(@types/react@18.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-switch': 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -10448,7 +10448,7 @@ snapshots:
       '@vanilla-extract/integration': 6.5.0(@types/node@20.16.5)
       outdent: 0.8.0
       postcss: 8.4.45
-      postcss-load-config: 4.0.2(postcss@8.4.45)(ts-node@10.9.2(@types/node@20.16.5)(typescript@5.6.2))
+      postcss-load-config: 4.0.2(postcss@8.4.45)(ts-node@10.9.2(typescript@5.6.2))
       vite: 5.4.4(@types/node@20.16.5)
     transitivePeerDependencies:
       - '@types/node'
@@ -11935,7 +11935,7 @@ snapshots:
       semver: 7.6.3
       strip-indent: 3.0.0
 
-  eslint-plugin-vitest@0.5.4(@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)(typescript@5.6.2)(vitest@2.0.5(@types/node@20.16.5)(jsdom@25.0.0)):
+  eslint-plugin-vitest@0.5.4(@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)(typescript@5.6.2)(vitest@2.0.5):
     dependencies:
       '@typescript-eslint/utils': 7.18.0(eslint@8.57.0)(typescript@5.6.2)
       eslint: 8.57.0
@@ -13617,7 +13617,7 @@ snapshots:
 
   possible-typed-array-names@1.0.0: {}
 
-  postcss-load-config@4.0.2(postcss@8.4.45)(ts-node@10.9.2(@types/node@20.16.5)(typescript@5.6.2)):
+  postcss-load-config@4.0.2(postcss@8.4.45)(ts-node@10.9.2(typescript@5.6.2)):
     dependencies:
       lilconfig: 3.1.2
       yaml: 2.5.1
@@ -14664,7 +14664,7 @@ snapshots:
 
   tslib@2.7.0: {}
 
-  tsup@7.3.0(postcss@8.4.45)(ts-node@10.9.2(@types/node@20.16.5)(typescript@5.6.2))(typescript@5.6.2):
+  tsup@7.3.0(postcss@8.4.45)(ts-node@10.9.2(typescript@5.6.2))(typescript@5.6.2):
     dependencies:
       bundle-require: 4.2.1(esbuild@0.19.12)
       cac: 6.7.14
@@ -14674,7 +14674,7 @@ snapshots:
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss-load-config: 4.0.2(postcss@8.4.45)(ts-node@10.9.2(@types/node@20.16.5)(typescript@5.6.2))
+      postcss-load-config: 4.0.2(postcss@8.4.45)(ts-node@10.9.2(typescript@5.6.2))
       resolve-from: 5.0.0
       rollup: 4.21.2
       source-map: 0.8.0-beta.0


### PR DESCRIPTION
## 변경사항

<!-- 어떤 변경사항이 있는지, PR 타이틀과 동일하다면 Skip -->

## 링크

<!-- 제플린 화면 링크 또는 관련된 대화가 이루어진 slack, height, figma 링크를 첨부. -->
https://sopt-makers.slack.com/archives/C07AFHC6LDB/p1727270019264379?thread_ts=1727269906.082949&cid=C07AFHC6LDB

## 시급한 정도

🏃‍♂️ 보통 : 최대한 빠르게 리뷰 부탁드립니다.

<!-- ⚠︎ 긴급 : 선 어프루브 후 리뷰를 부탁드립니다. (리뷰는 추후 반영)  -->
<!-- 🐢 천천히 : 급하지 않습니다. -->

## 기타 사항
- 스토리북은 배포된 makers npm 패키지로 작성되어 있어, SelectV2를 사용하기 위해 `packege.json`에서 `makers/ui` 버전을 2.3.0으로 수정했어요.
- 기존 Select의 스토리북 경로를 deprecated로 이동 했어요.

- TriggerContent 사용 여부에 따라 두개로 케이스를 나누어 간단하게 스토리를 작성했습니다.
- 자세한 경로는 아래와 같습니다.

<img width="203" alt="image" src="https://github.com/user-attachments/assets/73f7e1f0-6d86-44ad-babf-1501086b34b1">

https://github.com/user-attachments/assets/cacb87d3-ed60-4d30-a82e-0540b18ea4bf


https://github.com/user-attachments/assets/b5131e08-1f88-4be6-bf17-9d3a4ff32028




<!-- 변경사항이 큰 경우 집중해야 할 부분, 또는 불안해서 봐주었으면 하는 부분 등 -->

<!-- ### AS-IS -->

<!-- ### TO-BE -->
