### PR TITLE
feat(Tab): 유닛 테스트 코드를 작성합니다.

### DIFF
--- a/apps/docs/src/stories/Tab.stories.tsx
+++ b/apps/docs/src/stories/Tab.stories.tsx
@@ -1,19 +1,20 @@
-import type { Meta, StoryObj } from "@storybook/react";
-import { Tab } from "@sopt-makers/ui";
+import type { Meta, StoryObj } from '@storybook/react';
+import { Tab } from '@sopt-makers/ui';
 
 const meta = {
-  title: "Components/Tab",
+  title: 'Components/Tab',
   component: Tab,
-  tags: ["autodocs"],
+  tags: ['autodocs'],
   args: {
     tabItems: ['Tab1', 'Tab2', 'Tab3'],
     selectedInitial: 'Tab1',
+    translator: { Tab1: '탭1', Tab2: '탭2', Tab3: '탭3' },
   },
   argTypes: {
     style: { control: 'radio', options: ['primary', 'secondary'] },
     size: { control: 'radio', options: ['sm', 'md', 'lg'] },
     selectedInitial: { control: 'select', options: ['Tab1', 'Tab2', 'Tab3'] },
-  }
+  },
 } as Meta<typeof Tab>;
 
 export default meta;

--- a/packages/ui/Tab/test/Tab.test.tsx
+++ b/packages/ui/Tab/test/Tab.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import Tab from '../Tab';
+
+describe('Tab 컴포넌트는', () => {
+  const mockOnChange = vi.fn();
+  const tabItems = ['Tab1', 'Tab2', 'Tab3'];
+
+  function renderTab() {
+    render(<Tab onChange={mockOnChange} size='md' style='primary' tabItems={tabItems} />);
+  }
+
+  it('정상적으로 렌더링이 됩니다.', () => {
+    renderTab();
+
+    tabItems.forEach((item) => {
+      expect(screen.getByText(item)).toBeInTheDocument();
+    });
+  });
+
+  it('탭을 클릭하면 onChange 핸들러가 호출됩니다.', () => {
+    renderTab();
+
+    fireEvent.click(screen.getByText('Tab2'));
+
+    expect(mockOnChange).toHaveBeenCalledWith('Tab2');
+  });
+});


### PR DESCRIPTION
## 변경사항

close #155 

- tab 컴포넌트 unit 테스트를 작성했습니다.
  - tab 컴포넌트가 제대로 렌더링 되는지 여부
  - 각 tab을 클릭했을 때 onChange가 제대로 실행되는지 여부

- ui 관련된 부분은 크로마틱에서 확인 가능하여 제외했습니다.
  - tab 스토리 파일에서, translator 관련한 부분 확인을 위해서 args에 translator를 추가했습니다. 
  - translator는 tab의 실제 value를 대체할 텍스트를 나타내는 객체 입니다. ex) 실제 value는 `tab1`이고, 화면에 보여주고 싶은 text가 `탭1`이라면  `translator = { tab1: '탭1'}`와 같은 방식으로 작성하게 끔 코드가 구성되어있습니다.
  
<!-- 어떤 변경사항이 있는지, PR 타이틀과 동일하다면 Skip -->

## 링크

https://sopt-makers.slack.com/lists/T040QGZF77H/F07LCJ586TS?record_id=Rec07LCJ58NKS

<!-- 제플린 화면 링크 또는 관련된 대화가 이루어진 slack, height, figma 링크를 첨부. -->

## 시급한 정도

🏃‍♂️ 보통 : 최대한 빠르게 리뷰 부탁드립니다.

<!-- ⚠︎ 긴급 : 선 어프루브 후 리뷰를 부탁드립니다. (리뷰는 추후 반영)  -->
<!-- 🐢 천천히 : 급하지 않습니다. -->

## 기타 사항

- 추후 pr 작성 시, 스토리북 변경사항이 있을 때 github action으로 chromatic 배포를 자동으로 하는 워크플로우가 있었으면 하는데, 어떻게 생각하시는지 궁금합니다!
- unit 테스트를 어느정도 작성 후에 test 코드도 ci 걸어두면 좋을것 같아요!

<!-- 변경사항이 큰 경우 집중해야 할 부분, 또는 불안해서 봐주었으면 하는 부분 등 -->

<!-- ### AS-IS -->

<!-- ### TO-BE -->
