### PR TITLE
chore(ui, docs): 의존성 버전 workspace:^로 변경

### DIFF
--- a/.changeset/fluffy-dragons-shop.md
+++ b/.changeset/fluffy-dragons-shop.md
@@ -1,0 +1,5 @@
+---
+'@sopt-makers/ui': patch
+---
+
+fix dependancy (static version -> workspace:^)

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -13,10 +13,17 @@
     "chromatic": "npx chromatic --project-token=chpt_98c750b6bad066a"
   },
   "dependencies": {
+<<<<<<< Updated upstream
     "@sopt-makers/colors": "^3.0.2",
     "@sopt-makers/fonts": "^2.0.1",
     "@sopt-makers/icons": "^1.0.5",
     "@sopt-makers/ui": "^2.3.0"
+=======
+    "@sopt-makers/colors": "workspace:^",
+    "@sopt-makers/fonts": "workspace:^",
+    "@sopt-makers/icons": "workspace:^",
+    "@sopt-makers/ui": "workspace:^"
+>>>>>>> Stashed changes
   },
   "devDependencies": {
     "@storybook/addon-essentials": "^7.6.3",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -13,17 +13,10 @@
     "chromatic": "npx chromatic --project-token=chpt_98c750b6bad066a"
   },
   "dependencies": {
-<<<<<<< Updated upstream
-    "@sopt-makers/colors": "^3.0.2",
-    "@sopt-makers/fonts": "^2.0.1",
-    "@sopt-makers/icons": "^1.0.5",
-    "@sopt-makers/ui": "^2.3.0"
-=======
     "@sopt-makers/colors": "workspace:^",
     "@sopt-makers/fonts": "workspace:^",
     "@sopt-makers/icons": "workspace:^",
     "@sopt-makers/ui": "workspace:^"
->>>>>>> Stashed changes
   },
   "devDependencies": {
     "@storybook/addon-essentials": "^7.6.3",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -18,9 +18,15 @@
   "dependencies": {
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-switch": "^1.0.3",
+<<<<<<< Updated upstream
     "@sopt-makers/colors": "^3.0.2",
     "@sopt-makers/fonts": "^2.0.1",
     "@sopt-makers/icons": "^1.0.5",
+=======
+    "@sopt-makers/colors": "workspace:^",
+    "@sopt-makers/fonts": "workspace:^",
+    "@sopt-makers/icons": "workspace:^",
+>>>>>>> Stashed changes
     "@vanilla-extract/css": "^1.14.0",
     "@vanilla-extract/sprinkles": "1.6.1",
     "tsup": "^8.0.2"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -18,15 +18,9 @@
   "dependencies": {
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-switch": "^1.0.3",
-<<<<<<< Updated upstream
-    "@sopt-makers/colors": "^3.0.2",
-    "@sopt-makers/fonts": "^2.0.1",
-    "@sopt-makers/icons": "^1.0.5",
-=======
     "@sopt-makers/colors": "workspace:^",
     "@sopt-makers/fonts": "workspace:^",
     "@sopt-makers/icons": "workspace:^",
->>>>>>> Stashed changes
     "@vanilla-extract/css": "^1.14.0",
     "@vanilla-extract/sprinkles": "1.6.1",
     "tsup": "^8.0.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,13 +34,8 @@ importers:
   apps/docs:
     dependencies:
       '@sopt-makers/colors':
-<<<<<<< Updated upstream
-        specifier: ^3.0.2
-        version: 3.0.2
-=======
         specifier: workspace:^
         version: link:../../packages/colors
->>>>>>> Stashed changes
       '@sopt-makers/fonts':
         specifier: workspace:^
         version: link:../../packages/fonts
@@ -181,13 +176,8 @@ importers:
         specifier: ^1.0.3
         version: 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@sopt-makers/colors':
-<<<<<<< Updated upstream
-        specifier: ^3.0.2
-        version: 3.0.2
-=======
         specifier: workspace:^
         version: link:../colors
->>>>>>> Stashed changes
       '@sopt-makers/fonts':
         specifier: workspace:^
         version: link:../fonts
@@ -2320,26 +2310,6 @@ packages:
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
 
-<<<<<<< Updated upstream
-  '@sopt-makers/colors@3.0.2':
-    resolution: {integrity: sha512-DI7UBz584bGgZPLlAa7kL5mx6t6wMmhAKhWFwEjCBXgfFD0yvzkIH6f87nHsylAJ35lutEsF92hBjNKG0WSn5g==}
-
-  '@sopt-makers/fonts@2.0.1':
-    resolution: {integrity: sha512-glvB8aPm70XyOuhjrDW27wUH8i7BcVTiWByYAm3b1TMK5bBJzaX8Ga6Xgz5g9FY0VzDvBr/O5iXdMyO9Yhd4yA==}
-
-  '@sopt-makers/icons@1.0.5':
-    resolution: {integrity: sha512-u3mnMEyAs3tulfE9GYqjbmO6FAnzrp/AaCCKulwnVOw5O6GBXIoHe1A6lDxD+A73RoMu96QoL1OZ9y5h10Fe1w==}
-    peerDependencies:
-      react: ^18.2.0
-
-  '@sopt-makers/ui@2.3.0':
-    resolution: {integrity: sha512-NGASovJHlEwJB2oKGbo1SJj6zyYklZLK6A5d7L/ykCKW8qfBiR+l+Grm03n4J6ZRYK+9fkmHJz3hc/KiZ7y9OA==}
-    peerDependencies:
-      react: ^18.2.0
-      react-dom: ^18.2.0
-
-=======
->>>>>>> Stashed changes
   '@storybook/addon-actions@7.6.20':
     resolution: {integrity: sha512-c/GkEQ2U9BC/Ew/IMdh+zvsh4N6y6n7Zsn2GIhJgcu9YEAa5aF2a9/pNgEGBMOABH959XE8DAOMERw/5qiLR8g==}
 
@@ -9142,42 +9112,6 @@ snapshots:
 
   '@sinclair/typebox@0.27.8': {}
 
-<<<<<<< Updated upstream
-  '@sopt-makers/colors@3.0.2': {}
-
-  '@sopt-makers/fonts@2.0.1': {}
-
-  '@sopt-makers/icons@1.0.5(react@18.3.1)':
-    dependencies:
-      react: 18.3.1
-
-  '@sopt-makers/ui@2.3.0(@types/react-dom@18.3.0)(@types/react@18.3.5)(postcss@8.4.45)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.2)':
-    dependencies:
-      '@radix-ui/react-dialog': 1.1.1(@types/react-dom@18.3.0)(@types/react@18.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-switch': 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@sopt-makers/colors': 3.0.2
-      '@sopt-makers/fonts': 2.0.1
-      '@sopt-makers/icons': 1.0.5(react@18.3.1)
-      '@vanilla-extract/css': 1.15.5
-      '@vanilla-extract/sprinkles': 1.6.1(@vanilla-extract/css@1.15.5)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      tsup: 8.2.4(postcss@8.4.45)(typescript@5.6.2)
-    transitivePeerDependencies:
-      - '@microsoft/api-extractor'
-      - '@swc/core'
-      - '@types/react'
-      - '@types/react-dom'
-      - babel-plugin-macros
-      - jiti
-      - postcss
-      - supports-color
-      - tsx
-      - typescript
-      - yaml
-
-=======
->>>>>>> Stashed changes
   '@storybook/addon-actions@7.6.20':
     dependencies:
       '@storybook/core-events': 7.6.20

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,17 +34,22 @@ importers:
   apps/docs:
     dependencies:
       '@sopt-makers/colors':
+<<<<<<< Updated upstream
         specifier: ^3.0.2
         version: 3.0.2
+=======
+        specifier: workspace:^
+        version: link:../../packages/colors
+>>>>>>> Stashed changes
       '@sopt-makers/fonts':
-        specifier: ^2.0.1
-        version: 2.0.1
+        specifier: workspace:^
+        version: link:../../packages/fonts
       '@sopt-makers/icons':
-        specifier: ^1.0.5
-        version: 1.0.5(react@18.3.1)
+        specifier: workspace:^
+        version: link:../../packages/icons
       '@sopt-makers/ui':
-        specifier: ^2.3.0
-        version: 2.3.0(@types/react-dom@18.3.0)(@types/react@18.3.5)(postcss@8.4.45)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.2)
+        specifier: workspace:^
+        version: link:../../packages/ui
     devDependencies:
       '@storybook/addon-essentials':
         specifier: ^7.6.3
@@ -176,14 +181,19 @@ importers:
         specifier: ^1.0.3
         version: 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@sopt-makers/colors':
+<<<<<<< Updated upstream
         specifier: ^3.0.2
         version: 3.0.2
+=======
+        specifier: workspace:^
+        version: link:../colors
+>>>>>>> Stashed changes
       '@sopt-makers/fonts':
-        specifier: ^2.0.1
-        version: 2.0.1
+        specifier: workspace:^
+        version: link:../fonts
       '@sopt-makers/icons':
-        specifier: ^1.0.5
-        version: 1.0.5(react@18.3.1)
+        specifier: workspace:^
+        version: link:../icons
       '@vanilla-extract/css':
         specifier: ^1.14.0
         version: 1.15.5
@@ -2310,6 +2320,7 @@ packages:
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
 
+<<<<<<< Updated upstream
   '@sopt-makers/colors@3.0.2':
     resolution: {integrity: sha512-DI7UBz584bGgZPLlAa7kL5mx6t6wMmhAKhWFwEjCBXgfFD0yvzkIH6f87nHsylAJ35lutEsF92hBjNKG0WSn5g==}
 
@@ -2327,6 +2338,8 @@ packages:
       react: ^18.2.0
       react-dom: ^18.2.0
 
+=======
+>>>>>>> Stashed changes
   '@storybook/addon-actions@7.6.20':
     resolution: {integrity: sha512-c/GkEQ2U9BC/Ew/IMdh+zvsh4N6y6n7Zsn2GIhJgcu9YEAa5aF2a9/pNgEGBMOABH959XE8DAOMERw/5qiLR8g==}
 
@@ -9129,6 +9142,7 @@ snapshots:
 
   '@sinclair/typebox@0.27.8': {}
 
+<<<<<<< Updated upstream
   '@sopt-makers/colors@3.0.2': {}
 
   '@sopt-makers/fonts@2.0.1': {}
@@ -9162,6 +9176,8 @@ snapshots:
       - typescript
       - yaml
 
+=======
+>>>>>>> Stashed changes
   '@storybook/addon-actions@7.6.20':
     dependencies:
       '@storybook/core-events': 7.6.20
@@ -14616,33 +14632,6 @@ snapshots:
     optionalDependencies:
       postcss: 8.4.45
       typescript: 4.9.5
-    transitivePeerDependencies:
-      - jiti
-      - supports-color
-      - tsx
-      - yaml
-
-  tsup@8.2.4(postcss@8.4.45)(typescript@5.6.2):
-    dependencies:
-      bundle-require: 5.0.0(esbuild@0.23.1)
-      cac: 6.7.14
-      chokidar: 3.6.0
-      consola: 3.2.3
-      debug: 4.3.7
-      esbuild: 0.23.1
-      execa: 5.1.1
-      globby: 11.1.0
-      joycon: 3.1.1
-      picocolors: 1.1.0
-      postcss-load-config: 6.0.1(postcss@8.4.45)(yaml@2.5.1)
-      resolve-from: 5.0.0
-      rollup: 4.21.2
-      source-map: 0.8.0-beta.0
-      sucrase: 3.35.0
-      tree-kill: 1.2.2
-    optionalDependencies:
-      postcss: 8.4.45
-      typescript: 5.6.2
     transitivePeerDependencies:
       - jiti
       - supports-color


### PR DESCRIPTION
## 변경사항

<!-- 어떤 변경사항이 있는지, PR 타이틀과 동일하다면 Skip -->

- Storybook 패키지인 app/docs 패키지와 ui 패키지의 mds관련 패키지 의존성을 `workspace:^`로 변경합니다.
   - 각 패키지의 의존성을 빌드된 패키지 내의 버전을 사용하도록 해 작업시에도 타 패키지에의 변경사항을 쉽게 반영해서 작업할 수 있도록 하고, 하나의 패키지의 버전이 변경됐을 때 자동으로 다른 패키지에도 변경된 버전이 적용되도록 해 유지보수가 쉽도록 하기 위함이에요.(링크 참조)

## 링크

- https://sopt-makers.slack.com/archives/C07AFHC6LDB/p1728585131331459

<!-- 제플린 화면 링크 또는 관련된 대화가 이루어진 slack, height, figma 링크를 첨부. -->

## 시급한 정도

🏃‍♂️ 보통 : 최대한 빠르게 리뷰 부탁드립니다.

<!-- ⚠︎ 긴급 : 선 어프루브 후 리뷰를 부탁드립니다. (리뷰는 추후 반영)  -->
<!-- 🐢 천천히 : 급하지 않습니다. -->

## 기타 사항

처음에 버전 명시만 바꿔줬는데 테스트를 실패하더라구요?
그래서 원인이 뭔지 파악해보니 `workspace:^` 설정은 말그대로 빌드가 완료된 패키지 내의 버전을 바라보기때문에 패키지가 빌드가 되지 않으면 패키지 자체를 찾지 못하는 문제가 있었어요
그래서 [해당 커밋](https://github.com/sopt-makers/makers-design-system/commit/5b22280ac89f12fa7245389538bc15f41c3562a2)에서 테스트 워크플로에 빌드 명령어를 추가했고, 무사히 테스트를 통과했어요.
<!-- 변경사항이 큰 경우 집중해야 할 부분, 또는 불안해서 봐주었으면 하는 부분 등 -->

<!-- ### AS-IS -->

<!-- ### TO-BE -->
