### PR TITLE
refactor(Select): Select padding/border 명세와 상이한 부분 수정

### DIFF
--- a/.changeset/serious-beers-swim.md
+++ b/.changeset/serious-beers-swim.md
@@ -1,0 +1,5 @@
+---
+'@sopt-makers/ui': patch
+---
+
+SelectV2 피그마 명세와 상이한 border/padding 수정

--- a/packages/ui/Input/Select.tsx
+++ b/packages/ui/Input/Select.tsx
@@ -155,7 +155,7 @@ function SelectTriggerContent({ className, placeholder }: SelectTriggerContentPr
   const selectedLabel = selected ? selected.label : placeholder;
 
   return (
-    <div className={`${S.select} ${className ? className : ''}`}>
+    <div className={`${S.select} ${open ? S.focus : ''} ${className ? className : ''}`}>
       <p className={!selected ? S.selectPlaceholder : ''}>{selectedLabel}</p>
       <IconChevronDown
         style={{

--- a/packages/ui/Input/style.css.ts
+++ b/packages/ui/Input/style.css.ts
@@ -162,23 +162,17 @@ export const selectWrap = style({
 
 export const select = style({
   ...theme.fontsObject.BODY_2_16_M,
-  'color': theme.colors.white,
-  'width': '160px',
-  'height': '48px',
-  'borderRadius': '10px',
-  'background': theme.colors.gray800,
-  'border': '1px solid transparent',
-  'padding': '11px 16px',
-  'display': 'flex',
-  'justifyContent': 'space-between',
-  'alignItems': 'center',
-  'gap': '12px',
-  'cursor': 'pointer',
-  'transition': 'border 0.2s',
-
-  ':focus': {
-    border: `1px solid ${theme.colors.gray200}`,
-  },
+  color: theme.colors.white,
+  width: '160px',
+  height: '48px',
+  borderRadius: '10px',
+  background: theme.colors.gray800,
+  padding: '11px 16px',
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  gap: '12px',
+  cursor: 'pointer',
 });
 
 export const selectPlaceholder = style({
@@ -200,9 +194,6 @@ export const optionList = style({
   'animation': `${fadeIn} 0.5s forwards`,
   'overflowX': 'hidden',
 
-  '::-webkit-scrollbar': {
-    width: '16px',
-  },
   '::-webkit-scrollbar-thumb': {
     background: theme.colors.gray500,
     backgroundClip: 'padding-box',
@@ -300,4 +291,8 @@ export const buttonWithNoStyle = style({
   padding: 0,
   margin: 0,
   cursor: 'pointer',
+});
+
+export const width100 = style({
+  width: '100%',
 });

--- a/packages/ui/Input/style.css.ts
+++ b/packages/ui/Input/style.css.ts
@@ -292,7 +292,3 @@ export const buttonWithNoStyle = style({
   margin: 0,
   cursor: 'pointer',
 });
-
-export const width100 = style({
-  width: '100%',
-});


### PR DESCRIPTION
## 변경사항

close #173 

## padding값이 오른쪽에 더 적용된것 처럼 보이는 현상
```javascript
  '::-webkit-scrollbar': {
    width: '16px',
  },
```
스크롤바 영역이 16px 만큼 차지하고 있어서 그랬습니다. 피그마 디자인 비교했을 때 관련해서 적용해야하는 사항이 없어서 삭제했습니다.

## border 미적용 현상
 open 됐을 때 border가 아래 스타일 처럼 focus 선택자로 적용되고있었습니다. 해당 스타일은 trigger와 triggerContents로 컴포넌트가 나누어지면서 div태그인 triggerContents에 적용되는 스타일로 , div 태그에는 focus로 스타일을 받을 수 없기 때문에 일어난 현상이었습니다.
 
 ```javascript
export const select = style({
  ...theme.fontsObject.BODY_2_16_M,
  'color': theme.colors.white,
  'width': '160px',
  'height': '48px',
  'borderRadius': '10px',
  'background': theme.colors.gray800,
  'border': '1px solid transparent',
  'padding': '11px 16px',
  'display': 'flex',
  'justifyContent': 'space-between',
  'alignItems': 'center',
  'gap': '12px',
  'cursor': 'pointer',
  'transition': 'border 0.2s',

// 해당 focus 스타일 삭제
  ':focus': {
    border: `1px solid ${theme.colors.gray200}`,
  },
```

다음과 같이 따로 정의 되어있는 focus 스타일을 적용하여 해결했습니다.

```javascript
    <div className={`${S.select} ${open ? S.focus : ''} ${className ? className : ''}`}>
```

approve 받고 스토리북 배포하고, changeset 적용하겠습니다. 


<!-- 어떤 변경사항이 있는지, PR 타이틀과 동일하다면 Skip -->

## 링크

https://sopt-makers.slack.com/archives/C07AFHC6LDB/p1728690503017559
<!-- 제플린 화면 링크 또는 관련된 대화가 이루어진 slack, height, figma 링크를 첨부. -->

## 시급한 정도

🏃‍♂️ 보통 : 최대한 빠르게 리뷰 부탁드립니다.

<!-- ⚠︎ 긴급 : 선 어프루브 후 리뷰를 부탁드립니다. (리뷰는 추후 반영)  -->
<!-- 🐢 천천히 : 급하지 않습니다. -->

## 기타 사항

https://github.com/user-attachments/assets/8bdf69b0-ee52-495c-b0aa-390a6fbe7a25


<!-- 변경사항이 큰 경우 집중해야 할 부분, 또는 불안해서 봐주었으면 하는 부분 등 -->

<!-- ### AS-IS -->

<!-- ### TO-BE -->
