### PR TITLE
fix(Select): border 유무에 따라 size가 변형되지 않도록 수정합니다.

### DIFF
--- a/.changeset/sharp-boats-accept.md
+++ b/.changeset/sharp-boats-accept.md
@@ -1,0 +1,5 @@
+---
+'@sopt-makers/ui': patch
+---
+
+Fix Select border issue

--- a/packages/ui/Input/style.css.ts
+++ b/packages/ui/Input/style.css.ts
@@ -75,7 +75,7 @@ export const textarea = style({
 });
 
 export const focus = style({
-  border: `1px solid ${theme.colors.gray200}`,
+  boxShadow: `0 0 0 1px ${theme.colors.gray200}`,
   outline: 'none',
 });
 


### PR DESCRIPTION
## 변경사항

<!-- 어떤 변경사항이 있는지, PR 타이틀과 동일하다면 Skip -->

close #182 

#174 에 설명되어있듯이, `triggerContent`에 대한 `focus` style을 별도로 정의하게 되면서 `S.input` 스타일을 가져다가 사용하지 않게 되었고, `S.input`에 정의되어 있는 `border: 1px solid transparent`가 적용되지 않아서 border 유무에 따라 size가 변형되어 다른 요소가 밀리는 이슈가 발생했어요.

이를 해결하기 위해 별도로 정의한 `focus` style에 정의되어 있던 border를 box-shadow inset으로 변경하여 테두리가 생기더라도 요소의 size가 변형되지 않도록 하여 문제를 해결했어요.

- 논의하고 싶은 점
이렇게 되면 Select에서 Input의 공통 style을 참조하고 있지 않는데, Select를 Input으로 묶기보다 별도로 분리하는 건 어떤지에 대한 의견을 들어보고 싶어요!!

## 링크

<!-- 제플린 화면 링크 또는 관련된 대화가 이루어진 slack, height, figma 링크를 첨부. -->
https://sopt-makers.slack.com/lists/T040QGZF77H/F07LCJ586TS?record_id=Rec07T75VU4T1


## 시급한 정도

🏃‍♂️ 보통 : 최대한 빠르게 리뷰 부탁드립니다.

