### PR TITLE
fix(ui): Button 내 min-width 속성 추가

### DIFF
--- a/.changeset/stale-rules-rhyme.md
+++ b/.changeset/stale-rules-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@sopt-makers/ui': patch
+---
+
+Button 내 max-width 속성 추가

--- a/packages/ui/Button/style.css.ts
+++ b/packages/ui/Button/style.css.ts
@@ -11,6 +11,7 @@ export const root = style({
   border: 'none',
   cursor: 'pointer',
   fontWeight: 600,
+  minWidth: 'max-content',
 });
 
 const sprinkleProperties = defineProperties({


### PR DESCRIPTION
## 변경사항

<!-- 어떤 변경사항이 있는지, PR 타이틀과 동일하다면 Skip -->

- Button 컴포넌트의 minWidth 속성에 max-content 속성을 추가합니다.

## 링크

<!-- 제플린 화면 링크 또는 관련된 대화가 이루어진 slack, height, figma 링크를 첨부. -->

- https://sopt-makers.slack.com/archives/C07AFHC6LDB/p1730575141856619?thread_ts=1728023641.439659&cid=C07AFHC6LDB

## 시급한 정도

🏃‍♂️ 보통 : 최대한 빠르게 리뷰 부탁드립니다.

<!-- ⚠︎ 긴급 : 선 어프루브 후 리뷰를 부탁드립니다. (리뷰는 추후 반영)  -->
<!-- 🐢 천천히 : 급하지 않습니다. -->

## 기타 사항

<!-- 변경사항이 큰 경우 집중해야 할 부분, 또는 불안해서 봐주었으면 하는 부분 등 -->

<!-- ### AS-IS -->

<!-- ### TO-BE -->
