### PR TITLE
fix(ui): TextArea Value prop이 undefined일 경우 발생하는 타입 에러 수정

### DIFF
--- a/.changeset/pretty-eggs-teach.md
+++ b/.changeset/pretty-eggs-teach.md
@@ -1,0 +1,5 @@
+---
+'@sopt-makers/ui': patch
+---
+
+TextArea Value prop이 undefined일 경우 발생하는 타입 에러 수정

--- a/apps/docs/src/App.tsx
+++ b/apps/docs/src/App.tsx
@@ -70,7 +70,7 @@ function App() {
         rightAddon={{ onClick: () => handleTextareaSubmit() }}
         validationFn={textareaValidation}
         errorMessage='Error Message'
-        value={textarea}
+        // value={textarea}
         onChange={handleTextareaChange}
         maxLength={300}
       />

--- a/packages/ui/Input/TextArea.tsx
+++ b/packages/ui/Input/TextArea.tsx
@@ -35,7 +35,7 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>((props, forwarde
     isError,
     validationFn,
     errorMessage,
-    value = '',
+    value,
     disableEnterSubmit = false,
     maxLength,
     fixedHeight,
@@ -45,8 +45,8 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>((props, forwarde
   const { onChange, ...restInputProps } = inputProps;
   const { disabled, readOnly, required } = restInputProps;
 
-  const isValid = validationFn ? validationFn(value) : true;
-  const isEmpty = value.length === 0;
+  const isValid = validationFn ? validationFn(value ?? '') : true;
+  const isEmpty = value && value.length === 0;
 
   const submitButtonRef = useRef<HTMLButtonElement | null>(null);
 
@@ -171,8 +171,8 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>((props, forwarde
           )}
 
           {maxLength ? (
-            <p className={`${S.count} ${value.length > maxLength ? S.maxCount : ''}`}>
-              {value.length}/{maxLength}
+            <p className={`${S.count} ${!isEmpty && value && value.length > maxLength ? S.maxCount : ''}`}>
+              {value?.length}/{maxLength}
             </p>
           ) : null}
         </div>


### PR DESCRIPTION
## 변경사항

<!-- 어떤 변경사항이 있는지, PR 타이틀과 동일하다면 Skip -->

- MaxLength에서 발생하는 string.length가 value 가 undefined(e.g 빈 값일경우) 타입 추론을 하지 못하는 문제에서 발생합니다.
- 추후에 MaxLength의 경우에 FieldBox의 서브컴포넌트로 분리해 Textarea 자체에서는 MaxLength로 인한 타입 에러가 발생하지 않도록 방지해야 할 것 같습니다.

## 링크

<!-- 제플린 화면 링크 또는 관련된 대화가 이루어진 slack, height, figma 링크를 첨부. -->

https://sopt-makers.slack.com/archives/C07AFHC6LDB/p1732615027361309?thread_ts=1731917913.722789&cid=C07AFHC6LDB

## 시급한 정도

<!-- 🏃‍♂️ 보통 : 최대한 빠르게 리뷰 부탁드립니다. -->

⚠︎ 긴급 : 선 어프루브 후 리뷰를 부탁드립니다. (리뷰는 추후 반영)  
<!-- 🐢 천천히 : 급하지 않습니다. -->

## 기타 사항

<!-- 변경사항이 큰 경우 집중해야 할 부분, 또는 불안해서 봐주었으면 하는 부분 등 -->

<!-- ### AS-IS -->

<!-- ### TO-BE -->
