### PR TITLE
refactor(ui): SelectV2 TriggerContent 내 커스텀 Icon을 적용할 수 있도록 icon prop 추가.

### DIFF
--- a/.changeset/early-owls-protect.md
+++ b/.changeset/early-owls-protect.md
@@ -1,0 +1,5 @@
+---
+'@sopt-makers/ui': patch
+---
+
+SelectV2 TriggerContent 내 커스텀 Icon을 적용할 수 있도록 icon prop 추가.

--- a/packages/ui/Input/Select.tsx
+++ b/packages/ui/Input/Select.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { useState, useRef, useEffect, useCallback, createContext, useContext } from 'react';
 import { IconChevronDown, IconUser } from '@sopt-makers/icons';
 import { createPortal } from 'react-dom';
@@ -147,10 +148,13 @@ function SelectTrigger({ children }: SelectTriggerProps) {
 interface SelectTriggerContentProps {
   placeholder?: string;
   className?: string;
+  icon?: ReactNode;
 }
 
 // Select.TriggerContent 컴포넌트: trigger의 미리 정의된 UI
-function SelectTriggerContent({ placeholder, className }: SelectTriggerContentProps) {
+function SelectTriggerContent(props: SelectTriggerContentProps) {
+  const { placeholder, className, icon } = props;
+
   const { open, selected } = useSelectContext();
 
   const selectedLabel = selected ? selected.label : placeholder;
@@ -158,14 +162,18 @@ function SelectTriggerContent({ placeholder, className }: SelectTriggerContentPr
   return (
     <div className={`${S.select} ${open ? S.focus : ''} ${className}`}>
       <p className={!selected ? S.selectPlaceholder : ''}>{selectedLabel}</p>
-      <IconChevronDown
-        style={{
-          width: 20,
-          height: 20,
-          transform: open ? 'rotate(-180deg)' : '',
-          transition: 'all 0.3s ease',
-        }}
-      />
+      {icon ? (
+        icon
+      ) : (
+        <IconChevronDown
+          style={{
+            width: 20,
+            height: 20,
+            transform: open ? 'rotate(-180deg)' : '',
+            transition: 'all 0.3s ease',
+          }}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## 변경사항

<!-- 어떤 변경사항이 있는지, PR 타이틀과 동일하다면 Skip -->

- `SelectV2.TriggerContent`의 아이콘이 `ChevronDown`만으로 고정되어 있던 형태에서, ReactNode type의 `icon` 을 추가하여 다양한 아이콘을 추가할 수 있도록 수정합니다.

## 링크

<!-- 제플린 화면 링크 또는 관련된 대화가 이루어진 slack, height, figma 링크를 첨부. -->

- https://sopt-makers.slack.com/archives/C07AFHC6LDB/p1734106307427189

## 시급한 정도

🏃‍♂️ 보통 : 최대한 빠르게 리뷰 부탁드립니다.

<!-- ⚠︎ 긴급 : 선 어프루브 후 리뷰를 부탁드립니다. (리뷰는 추후 반영)  -->
<!-- 🐢 천천히 : 급하지 않습니다. -->

## 기타 사항

<!-- 변경사항이 큰 경우 집중해야 할 부분, 또는 불안해서 봐주었으면 하는 부분 등 -->

<!-- ### AS-IS -->

<!-- ### TO-BE -->
