### PR TITLE
fix(ui): Add `<FieldBox.TopAddon />` in TextField's topAddon prop.

### DIFF
--- a/.changeset/tough-ligers-applaud.md
+++ b/.changeset/tough-ligers-applaud.md
@@ -1,0 +1,5 @@
+---
+'@sopt-makers/ui': patch
+---
+
+fix: Add <FieldBox.TopAddon /> in TextField's topAddon prop.

--- a/packages/ui/Input/TextField.tsx
+++ b/packages/ui/Input/TextField.tsx
@@ -52,7 +52,9 @@ const TextField = forwardRef<HTMLInputElement, TextFieldProps>((props, ref) => {
       ref={ref}
       topAddon={
         labelText || descriptionText ? (
-          <FieldBox.Label description={descriptionText} label={labelText} required={required} />
+          <FieldBox.TopAddon
+            leftAddon={<FieldBox.Label description={descriptionText} label={labelText} required={required} />}
+          />
         ) : (
           topAddon
         )


### PR DESCRIPTION
## 변경사항

<!-- 어떤 변경사항이 있는지, PR 타이틀과 동일하다면 Skip -->

- TextField의 topAddon에 새로 변경된 FieldBox의 레이아웃이 적용되지 않았던 문제를 수정했어요.
- FieldBox의 TopAddon을 감싸줌으로써 온전한 FieldBox의 레이아웃을 가질 수 있도록 수정했습니다.

## 링크

<!-- 제플린 화면 링크 또는 관련된 대화가 이루어진 slack, height, figma 링크를 첨부. -->

- https://sopt-makers.slack.com/archives/C042T8GEA0Y/p1736695443645079?thread_ts=1736683244.972439&cid=C042T8GEA0Y

## 시급한 정도

🏃‍♂️ 보통 : 최대한 빠르게 리뷰 부탁드립니다.

<!-- ⚠︎ 긴급 : 선 어프루브 후 리뷰를 부탁드립니다. (리뷰는 추후 반영)  -->
<!-- 🐢 천천히 : 급하지 않습니다. -->

## 기타 사항

<!-- 변경사항이 큰 경우 집중해야 할 부분, 또는 불안해서 봐주었으면 하는 부분 등 -->

<!-- ### AS-IS -->

<!-- ### TO-BE -->
