### PR TITLE
feat(ui): TextField rigntAddon 옵션 추가.

### DIFF
--- a/apps/docs/src/stories/TextField.stories.tsx
+++ b/apps/docs/src/stories/TextField.stories.tsx
@@ -1,13 +1,21 @@
-import { ChangeEvent, useState, type InputHTMLAttributes } from 'react';
+import { ChangeEvent, ReactNode, useState, type InputHTMLAttributes } from 'react';
 import { StoryObj } from '@storybook/react';
 import { TextField } from '@sopt-makers/ui';
+import { IconSend } from '@sopt-makers/icons';
 
 interface TextFieldProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'value'> {
+  className?: string;
+  topAddon?: ReactNode;
+  bottomAddon?: ReactNode;
+  rightAddon?: ReactNode;
   labelText?: string;
   descriptionText?: string;
-  value: string;
+  required?: boolean;
   errorMessage?: string;
+  value?: string;
+  // isError -> validationFn 순서로 적용
   isError?: boolean;
+  validationFn?: (input: string) => boolean;
 }
 
 const useTextField = (props: TextFieldProps) => {
@@ -19,6 +27,10 @@ const useTextField = (props: TextFieldProps) => {
 
   return <TextField {...props} value={text} onChange={handleTextChange} />;
 };
+
+/**
+ * `TextField` 컴포넌트는 **[FieldBox](https://main--6571c88390d085ed7efcce84.chromatic.com/?path=/docs/components-fieldbox--docs)**를 부모 컴포넌트로 삼는 Input 컴포넌트입니다.
+ */
 
 export default {
   title: 'Components/Input/TextField',
@@ -132,6 +144,18 @@ export const Error: StoryObj<TextFieldProps> = {
     placeholder: 'Placeholder...',
     isError: true,
     errorMessage: 'error message',
+    required: true,
+    readOnly: false,
+    disabled: false,
+  },
+};
+
+export const HasRightAddon: StoryObj<TextFieldProps> = {
+  args: {
+    labelText: 'Label',
+    descriptionText: 'Description',
+    placeholder: 'Placeholder...',
+    rightAddon: <IconSend style={{ width: '24px', height: '24px' }} />,
     required: true,
     readOnly: false,
     disabled: false,

--- a/packages/ui/Input/TextField.tsx
+++ b/packages/ui/Input/TextField.tsx
@@ -2,10 +2,11 @@ import { type ReactNode, type InputHTMLAttributes, forwardRef } from 'react';
 import { FieldBox } from 'FieldBox';
 import * as S from './style.css';
 
-interface TextFieldProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'value'> {
+export interface TextFieldProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'value'> {
   className?: string;
   topAddon?: ReactNode;
   bottomAddon?: ReactNode;
+  rightAddon?: ReactNode;
   labelText?: string;
   descriptionText?: string;
   required?: boolean;
@@ -21,6 +22,7 @@ const TextField = forwardRef<HTMLInputElement, TextFieldProps>((props, ref) => {
     className,
     topAddon,
     bottomAddon,
+    rightAddon,
     labelText,
     descriptionText,
     required,
@@ -60,7 +62,10 @@ const TextField = forwardRef<HTMLInputElement, TextFieldProps>((props, ref) => {
         )
       }
     >
-      <input {...inputProps} className={`${S.input} ${hasError() ? S.inputError : ''}`} value={value} />
+      <div className={`${S.inputWrapper} ${hasError() ? S.inputError : ''}`}>
+        <input {...inputProps} className={S.input} value={value} />
+        {rightAddon}
+      </div>
     </FieldBox>
   );
 });

--- a/packages/ui/Input/style.css.ts
+++ b/packages/ui/Input/style.css.ts
@@ -23,8 +23,8 @@ export const label = style({
   color: theme.colors.white,
 });
 
-export const input = style({
-  ...theme.fontsObject.BODY_2_16_M,
+export const inputWrapper = style({
+  'display': 'flex',
   'background': theme.colors.gray800,
   'border': '1px solid transparent',
   'borderRadius': '10px',
@@ -34,11 +34,23 @@ export const input = style({
   'color': theme.colors.white,
   'boxSizing': 'border-box',
 
+  ':focus-within': {
+    border: `1px solid ${theme.colors.gray200}`,
+  },
+});
+
+export const input = style({
+  ...theme.fontsObject.BODY_2_16_M,
+  'flex': 1,
+  'border': 0,
+  'background': 'transparent',
+  'color': theme.colors.white,
+  'boxSizing': 'border-box',
+
   '::placeholder': {
     color: theme.colors.gray300,
   },
   ':focus': {
-    border: `1px solid ${theme.colors.gray200}`,
     outline: 'none',
   },
   ':disabled': {


### PR DESCRIPTION
## 변경사항

<!-- 어떤 변경사항이 있는지, PR 타이틀과 동일하다면 Skip -->

- TextField 컴포넌트 우측에 다양한 요소를 넣을 수 있는 rigntAddon prop 옵션을 추가했어요.
- storybook 문서에 rightAddon 관련 스토리를 추가했어요.

## 링크

<!-- 제플린 화면 링크 또는 관련된 대화가 이루어진 slack, height, figma 링크를 첨부. -->

- https://sopt-makers.slack.com/archives/C07AFHC6LDB/p1736942771125269?thread_ts=1736929729.011059&cid=C07AFHC6LDB

## 시급한 정도

🏃‍♂️ 보통 : 최대한 빠르게 리뷰 부탁드립니다.

<!-- ⚠︎ 긴급 : 선 어프루브 후 리뷰를 부탁드립니다. (리뷰는 추후 반영)  -->
<!-- 🐢 천천히 : 급하지 않습니다. -->

## 기타 사항

<img width="1034" alt="image" src="https://github.com/user-attachments/assets/932a68d6-0494-418b-a808-3603569fc5b9" />


<!-- 변경사항이 큰 경우 집중해야 할 부분, 또는 불안해서 봐주었으면 하는 부분 등 -->

<!-- ### AS-IS -->

<!-- ### TO-BE -->
