### PR TITLE
fix(TextArea): inputError가 적용되었을 때 focus 스타일이 적용되지 않도록 수정

### DIFF
--- a/.changeset/tender-cougars-deny.md
+++ b/.changeset/tender-cougars-deny.md
@@ -1,0 +1,5 @@
+---
+'@sopt-makers/ui': patch
+---
+
+feat: TextArea에서 inputError가 적용된 경우 focus 스타일이 나타나지 않도록 수정"

--- a/packages/ui/Input/TextArea.tsx
+++ b/packages/ui/Input/TextArea.tsx
@@ -138,7 +138,7 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>((props, forwarde
     <div className={className}>
       {isValidElement(topAddon) ? topAddon : labelEl}
 
-      <div className={`${S.textareaWrap} ${hasError ? S.inputError : ''} ${isFocused ? S.focus : ''}`}>
+      <div className={`${S.textareaWrap} ${hasError ? S.inputError : ''} ${!hasError && isFocused ? S.focus : ''}`}>
         <textarea
           ref={forwardedRef}
           {...restInputProps}


### PR DESCRIPTION
## 변경사항

<!-- 어떤 변경사항이 있는지, PR 타이틀과 동일하다면 Skip -->
<img width="350" alt="image" src="https://github.com/user-attachments/assets/f924a0dc-83ae-4462-9a83-f8c7ee4c9753" />

<img width="350" alt="image" src="https://github.com/user-attachments/assets/c98361fb-115c-4df1-ad55-7b63a27b5f46" />

- inputError의 focus상태일때 왼쪽의 스타일에서 오른쪽의 스타일이 되도록 수정하였습니다.
- inputError가 적용되었을 때 focus 스타일이 적용되지 않도록 `${!hasError && isFocused ? S.focus : ''}` 이와 같이 `!hasError `조건을 추가하였습니다.

## 링크

<!-- 제플린 화면 링크 또는 관련된 대화가 이루어진 slack, height, figma 링크를 첨부. -->
<img width="514" alt="image" src="https://github.com/user-attachments/assets/a114d2df-c2fb-4062-b769-4f27c202aad3" />

- 메이커스 [디자인 시스템 피그마](https://www.figma.com/design/ZuAGH1zZDxduHsjCZm8kfH/%F0%9F%9A%80-makers-design-system?node-id=905-4571&p=f&t=2YEnW22U6AYqWrob-0)를 확인한 결과 error 상태일 때 active 스타일이 별도로 정의되어 있지 않아 해당 방식으로 수정했습니다..!
 혹시 수정전의 스타일이 의도된 스타일이 맞다면 말씀 부탁드립니다!😀



## 시급한 정도

🏃‍♂️ 보통 : 최대한 빠르게 리뷰 부탁드립니다.

<!-- ⚠︎ 긴급 : 선 어프루브 후 리뷰를 부탁드립니다. (리뷰는 추후 반영)  -->
<!-- 🐢 천천히 : 급하지 않습니다. -->

## 기타 사항
- 기존에 플그팀에서는 inputError가 적용될 때 focus 스타일이 적용되지 않도록 하기 위해 mds가 아닌 별도의 컴포넌트를 만들어 사용하고 있었습니다. 이번 SP0 작업에서 해당 TextArea를 mds로 사용하기 위해 해당 부분을 수정했습니다.


<!-- 변경사항이 큰 경우 집중해야 할 부분, 또는 불안해서 봐주었으면 하는 부분 등 -->

<!-- ### AS-IS -->

<!-- ### TO-BE -->
