### PR TITLE
docs: cursor rule + vscode task 세팅

### DIFF
--- a/.cursor/rules/rules.mdc
+++ b/.cursor/rules/rules.mdc
@@ -1,0 +1,36 @@
+---
+description: 
+globs: 
+alwaysApply: true
+---
+You are an expert in TypeScript,React and Vanilla Extract.
+
+we are managing all packages by pnpm package manager and turborepo.
+
+## Ground rules
+- 대답은 될 수 있으면 한국어로 할 것.
+
+## Tech Stack
+- Turborepo를 통해서 모노레포 체계를 사용 중.
+  - apps/docs: UI component 들의 스토리북 패키지
+  - packages: Makers라는 사내 조직에서 이용 가능한 디자인 시스템 패키지들
+
+- pacakges 내 주요 패키지들
+  - packages/ui: ui 컴포넌트들을 관리하는 패키지
+  - packages/colors: 디자인 시스템 칼러들을 관리하는 패키지
+  - packages/fonts: 디자인 시스템 폰트들을 관리하는 패키지
+  - packages/icons: 디자인 시스템 아이콘들을 관리하는 패키지
+
+- 메인 기술 스택
+  - react, turborepo, vanilla-extract, radix-ui, vitest, changeset, tsup
+
+## Coding Rules
+- Prefer functional components over class components. Avoid using class components.
+- Use interfaces to define the props types for components.
+- Prefer writing CSS styles for a specific component within the same file. However, it's acceptable to separate the styles if they grow too large.
+- Scalability and reusability are the top priorities when designing components.
+- Use descriptive variable names with auxiliary verbs (e.g., isLoading, hasError).
+- Prefer a co-located structure. Group related concerns together in the same place.
+- Prefer iteration and modularization over code duplication.
+- Always use absolute path.
+

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,11 @@
 {
   "typescript.tsdk": "node_modules/typescript/lib",
   "editor.formatOnSave": true,
-  "editor.defaultFormatter": "esbenp.prettier-vscode"
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "terminal.integrated.profiles.osx": {
+    "zsh": {
+      "path": "/bin/zsh",
+      "args": ["-l", "-i"]
+    }
+  }
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,18 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Dev start",
+      "type": "shell",
+      "command": "./scripts/vscode.sh",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "problemMatcher": [],
+      "runOptions": {
+        "runOn": "folderOpen"
+      }
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,11 @@
     "lint": "turbo run lint",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "publish-packages": "turbo run build lint && changeset publish",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "build:ui": "pnpm build --filter @sopt-makers/ui",
+    "build:icon": "pnpm build --filter @sopt-makers/icons",
+    "build:font": "pnpm build --filter @sopt-makers/fonts",
+    "build:color": "pnpm build --filter @sopt-makers/colors"
   },
   "devDependencies": {
     "eslint": "^8.48.0",

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "publish-packages": "turbo run build lint && changeset publish",
     "prepare": "husky install",
     "build:ui": "pnpm build --filter @sopt-makers/ui",
-    "build:icon": "pnpm build --filter @sopt-makers/icons",
-    "build:font": "pnpm build --filter @sopt-makers/fonts",
-    "build:color": "pnpm build --filter @sopt-makers/colors"
+    "build:icons": "pnpm build --filter @sopt-makers/icons",
+    "build:fonts": "pnpm build --filter @sopt-makers/fonts",
+    "build:colors": "pnpm build --filter @sopt-makers/colors"
   },
   "devDependencies": {
     "eslint": "^8.48.0",

--- a/scripts/vscode.sh
+++ b/scripts/vscode.sh
@@ -1,0 +1,25 @@
+if [ -s ${HOME}/.nvm/nvm.sh ]; then
+    . ${HOME}/.nvm/nvm.sh
+fi
+
+pnpm install
+
+if [ ! -d "packages/ui/dist" ]; then
+    pnpm build:ui
+fi
+
+if [ ! -d "packages/icons/dist" ]; then
+    pnpm build:icon
+fi
+
+if [ ! -d "packages/fonts/dist" ]; then
+    pnpm build:font
+fi
+
+if [ ! -d "packages/colors/dist" ]; then
+    pnpm build:color
+fi
+
+pnpm test
+
+

--- a/scripts/vscode.sh
+++ b/scripts/vscode.sh
@@ -4,21 +4,13 @@ fi
 
 pnpm install
 
-if [ ! -d "packages/ui/dist" ]; then
-    pnpm build:ui
-fi
+packages=("ui" "icons" "fonts" "colors")
 
-if [ ! -d "packages/icons/dist" ]; then
-    pnpm build:icon
-fi
-
-if [ ! -d "packages/fonts/dist" ]; then
-    pnpm build:font
-fi
-
-if [ ! -d "packages/colors/dist" ]; then
-    pnpm build:color
-fi
+for pkg in ${packages[@]}; do
+    if [ ! -d "packages/${pkg}/dist" ]; then
+        pnpm build:${pkg}
+    fi
+done
 
 pnpm test
 


### PR DESCRIPTION
## 변경사항

<!-- 어떤 변경사항이 있는지, PR 타이틀과 동일하다면 Skip -->

1. 먼저 `cursor` 룰을 세팅했어요. 룰에 따라 커서와의 `chat` 혹은 프롬프트 기반 코드 추천을 커스터마이징하였어요. 프로젝트 구조와 코딩 컨벤션 등을 추가해주었어요.
2. vscode task를 추가해주었어요. 프로젝트 폴더를 킬때마다 Dev start라는 태스크가 실행돼요. 먼저 `ui` `color` `font` `icon` 은 `dist` 폴더를 기준으로 모듈이 호출되기 때문에 빌드되지 않은 상태라면 빌드 실행을 추가적으로 해주어야 했어요. 따라서 빌드된 결과물이 없다면 IDE를 킬 시에 자동으로 `build`가 진행될 수 있도록 하였어요. 또한 UI `vitest`를 진행하면서 테스트를 추가적으로 진행해주었어요.

## 링크

<!-- 제플린 화면 링크 또는 관련된 대화가 이루어진 slack, height, figma 링크를 첨부. -->

## 시급한 정도

🏃‍♂️ 천천히 : 급하지 않습니다.

<!-- ⚠︎ 긴급 : 선 어프루브 후 리뷰를 부탁드립니다. (리뷰는 추후 반영)  -->
<!-- 🐢 천천히 : 급하지 않습니다. -->

## 기타 사항

<!-- 변경사항이 큰 경우 집중해야 할 부분, 또는 불안해서 봐주었으면 하는 부분 등 -->

<!-- ### AS-IS -->

<!-- ### TO-BE -->

<img width="704" alt="image" src="https://github.com/user-attachments/assets/a6d8c59d-11b9-4798-aca0-72561f07f2b6" />

