### PR TITLE
feat(ui): Tab 컴포넌트 타입 확장

### DIFF
--- a/apps/docs/src/stories/Tab.stories.tsx
+++ b/apps/docs/src/stories/Tab.stories.tsx
@@ -1,5 +1,5 @@
+import { Tab, Tag } from '@sopt-makers/ui';
 import type { Meta, StoryObj } from '@storybook/react';
-import { Tab } from '@sopt-makers/ui';
 
 const meta = {
   title: 'Components/Tab',
@@ -31,5 +31,32 @@ export const Secondary: StoryObj = {
   args: {
     style: 'secondary',
     size: 'lg',
+  },
+};
+
+export const WithComponent: StoryObj = {
+  args: {
+    style: 'primary',
+    size: 'md',
+    translator: {
+      Tab1: (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.4rem' }}>
+          탭1
+          <Tag>1</Tag>
+        </div>
+      ),
+      Tab2: (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.4rem' }}>
+          탭2
+          <Tag>2</Tag>
+        </div>
+      ),
+      Tab3: (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '0.4rem' }}>
+          탭3
+          <Tag>3</Tag>
+        </div>
+      ),
+    },
   },
 };

--- a/packages/ui/Tab/Tab.tsx
+++ b/packages/ui/Tab/Tab.tsx
@@ -1,6 +1,6 @@
-import { useState } from 'react';
+import { ReactNode, useState } from 'react';
 import * as S from './style.css';
-import { createTabVariant, createTabItemVariant } from './utils';
+import { createTabItemVariant, createTabVariant } from './utils';
 
 export type TabStyle = 'primary' | 'secondary';
 export type TabSize = 'sm' | 'md' | 'lg';
@@ -10,7 +10,7 @@ interface TabProps<T extends string> {
   size: TabSize;
   tabItems: T[];
   selectedInitial?: T;
-  translator?: Record<T, string>;
+  translator?: Record<T, ReactNode>;
   className?: string;
   onChange: (selected: T) => void;
 }
@@ -26,20 +26,29 @@ function Tab<T extends string>(props: TabProps<T>) {
   const handleClickTabItem = (item: T) => {
     setSelected(item);
     onChange(item);
-  }
+  };
 
-  return <div className={`${S.tab} ${tabVariant} ${className}`}>
-    {tabItems.map(item => {
-      const isSelected = selected === item ? 'selected' : '';
-      return <div className={S.tabItemWrap} key={item}>
-        <button className={`${S.tabItem} ${tabItemVariant} ${isSelected} ${S.fontStyles[size]}`} onClick={() => { handleClickTabItem(item); }} type="button">
-          {translator ? translator[item] : item}
-        </button>
-        <div className={`${S.tabItemUnderline} ${isSelected}`} />
-      </div>
-    }
-    )}
-  </div>
+  return (
+    <div className={`${S.tab} ${tabVariant} ${className}`}>
+      {tabItems.map((item) => {
+        const isSelected = selected === item ? 'selected' : '';
+        return (
+          <div className={S.tabItemWrap} key={item}>
+            <button
+              className={`${S.tabItem} ${tabItemVariant} ${isSelected} ${S.fontStyles[size]}`}
+              onClick={() => {
+                handleClickTabItem(item);
+              }}
+              type='button'
+            >
+              {translator ? translator[item] : item}
+            </button>
+            <div className={`${S.tabItemUnderline} ${isSelected}`} />
+          </div>
+        );
+      })}
+    </div>
+  );
 }
 
 export default Tab;


### PR DESCRIPTION
## 변경사항

Tab의 translator 타입을 ` Record<T, string>`에서 ` Record<T, ReactNode>`로 변경하여 컴포넌트도 탭 내용에 추가될 수 있도록 수정했습니다.

## 링크

<!-- 제플린 화면 링크 또는 관련된 대화가 이루어진 slack, height, figma 링크를 첨부. -->

[피그마 링크](https://www.figma.com/design/wQRUlMHjwFgWEvQs5tvEFO?node-id=127-14374&m=dev#1200255941)

## 시급한 정도

 ⚠︎ 긴급 : 선 어프루브 후 리뷰를 부탁드립니다. (리뷰는 추후 반영) 
<!-- 🐢 천천히 : 급하지 않습니다. -->


<!-- ### AS-IS -->

<!-- ### TO-BE -->
