### PR TITLE
[Style] textfield 컴포넌트에 background 속성을 하나 분기처리해주었습니다.

### DIFF
--- a/.changeset/smooth-cameras-provide.md
+++ b/.changeset/smooth-cameras-provide.md
@@ -1,0 +1,6 @@
+---
+'@sopt-makers/ui': patch
+'docs': patch
+---
+
+style: textfield background 추가

--- a/apps/docs/src/App.tsx
+++ b/apps/docs/src/App.tsx
@@ -62,6 +62,16 @@ function App() {
         validationFn={inputValidation}
         value={input}
         onChange={handleInputChange}
+        place={'admin'}
+      />
+      <TextField
+        placeholder='Placeholder...'
+        required
+        labelText='Label'
+        descriptionText='description'
+        validationFn={inputValidation}
+        value={input}
+        onChange={handleInputChange}
       />
       <TextArea
         placeholder='Placeholder...'

--- a/packages/ui/Input/TextField.tsx
+++ b/packages/ui/Input/TextField.tsx
@@ -14,6 +14,7 @@ interface TextFieldProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'va
   value?: string;
   // isError -> validationFn 순서로 적용
   isError?: boolean;
+  place?: 'admin';
   validationFn?: (input: string) => boolean;
 }
 
@@ -30,6 +31,7 @@ const TextField = forwardRef<HTMLInputElement, TextFieldProps>((props, ref) => {
     value,
     isError,
     validationFn,
+    place,
     ...inputProps
   } = props;
 
@@ -62,7 +64,7 @@ const TextField = forwardRef<HTMLInputElement, TextFieldProps>((props, ref) => {
         )
       }
     >
-      <div className={`${S.inputWrapper} ${hasError() ? S.inputError : ''}`}>
+      <div className={`${S.inputWrapper({ place })} ${hasError() ? S.inputError : ''}`}>
         <input {...inputProps} className={S.input} value={value} />
         {rightAddon}
       </div>

--- a/packages/ui/Input/style.css.ts
+++ b/packages/ui/Input/style.css.ts
@@ -1,4 +1,5 @@
 import { globalStyle, style, keyframes, styleVariants } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
 import theme from '../theme.css';
 
 const fadeInDown = keyframes({
@@ -23,20 +24,29 @@ export const label = style({
   color: theme.colors.white,
 });
 
-export const inputWrapper = style({
-  'display': 'flex',
-  'alignItems': 'center',
-  'background': theme.colors.gray800,
-  'border': '1px solid transparent',
-  'borderRadius': '10px',
-  'width': '100%',
-  'height': '48px',
-  'padding': '10px 16px',
-  'color': theme.colors.white,
-  'boxSizing': 'border-box',
+export const inputWrapper = recipe({
+  base: {
+    'display': 'flex',
+    'alignItems': 'center',
+    'background': theme.colors.gray800,
+    'border': '1px solid transparent',
+    'borderRadius': '10px',
+    'width': '100%',
+    'height': '48px',
+    'padding': '10px 16px',
+    'color': theme.colors.white,
+    'boxSizing': 'border-box',
 
-  ':focus-within': {
-    border: `1px solid ${theme.colors.gray200}`,
+    ':focus-within': {
+      border: `1px solid ${theme.colors.gray200}`,
+    },
+  },
+  variants: {
+    place: {
+      admin: {
+        background: theme.colors.gray700,
+      },
+    },
   },
 });
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -28,6 +28,7 @@
     "@sopt-makers/fonts": "workspace:^",
     "@sopt-makers/icons": "workspace:^",
     "@vanilla-extract/css": "^1.14.0",
+    "@vanilla-extract/recipes": "^0.5.5",
     "@vanilla-extract/sprinkles": "^1.6.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,7 +123,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^7.2.0
-        version: 7.3.0(postcss@8.4.47)(ts-node@10.9.2(@types/node@22.7.9)(typescript@5.6.3))(typescript@5.6.3)
+        version: 7.3.0(postcss@8.4.47)(ts-node@10.9.2(typescript@5.6.3))(typescript@5.6.3)
       typescript:
         specifier: ^5.2.2
         version: 5.6.3
@@ -141,7 +141,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^7.2.0
-        version: 7.3.0(postcss@8.4.47)(ts-node@10.9.2(@types/node@22.7.9)(typescript@5.6.3))(typescript@5.6.3)
+        version: 7.3.0(postcss@8.4.47)(ts-node@10.9.2(typescript@5.6.3))(typescript@5.6.3)
       typescript:
         specifier: ^5.2.2
         version: 5.6.3
@@ -160,7 +160,7 @@ importers:
         version: 18.3.12
       tsup:
         specifier: ^7.2.0
-        version: 7.3.0(postcss@8.4.47)(ts-node@10.9.2(@types/node@22.7.9)(typescript@5.6.3))(typescript@5.6.3)
+        version: 7.3.0(postcss@8.4.47)(ts-node@10.9.2(typescript@5.6.3))(typescript@5.6.3)
       typescript:
         specifier: ^5.2.2
         version: 5.6.3
@@ -187,6 +187,9 @@ importers:
       '@vanilla-extract/css':
         specifier: ^1.14.0
         version: 1.16.0
+      '@vanilla-extract/recipes':
+        specifier: ^0.5.5
+        version: 0.5.5(@vanilla-extract/css@1.16.0)
       '@vanilla-extract/sprinkles':
         specifier: ^1.6.1
         version: 1.6.1(@vanilla-extract/css@1.16.0)
@@ -3071,6 +3074,11 @@ packages:
 
   '@vanilla-extract/private@1.0.6':
     resolution: {integrity: sha512-ytsG/JLweEjw7DBuZ/0JCN4WAQgM9erfSTdS1NQY778hFQSZ6cfCDEZZ0sgVm4k54uNz6ImKB33AYvSR//fjxw==}
+
+  '@vanilla-extract/recipes@0.5.5':
+    resolution: {integrity: sha512-VadU7+IFUwLNLMgks29AHav/K5h7DOEfTU91RItn5vwdPfzduodNg317YbgWCcpm7FSXkuR3B3X8ZOi95UOozA==}
+    peerDependencies:
+      '@vanilla-extract/css': ^1.0.0
 
   '@vanilla-extract/sprinkles@1.6.1':
     resolution: {integrity: sha512-N/RGKwGAAidBupZ436RpuweRQHEFGU+mvAqBo8PRMAjJEmHoPDttV8RObaMLrJHWLqvX+XUMinHUnD0hFRQISw==}
@@ -10742,6 +10750,10 @@ snapshots:
 
   '@vanilla-extract/private@1.0.6': {}
 
+  '@vanilla-extract/recipes@0.5.5(@vanilla-extract/css@1.16.0)':
+    dependencies:
+      '@vanilla-extract/css': 1.16.0
+
   '@vanilla-extract/sprinkles@1.6.1(@vanilla-extract/css@1.16.0)':
     dependencies:
       '@vanilla-extract/css': 1.16.0
@@ -10751,7 +10763,7 @@ snapshots:
       '@vanilla-extract/integration': 6.5.0(@types/node@22.7.9)
       outdent: 0.8.0
       postcss: 8.4.47
-      postcss-load-config: 4.0.2(postcss@8.4.47)(ts-node@10.9.2(@types/node@22.7.9)(typescript@5.6.3))
+      postcss-load-config: 4.0.2(postcss@8.4.47)(ts-node@10.9.2(typescript@5.6.3))
       vite: 5.4.10(@types/node@22.7.9)
     transitivePeerDependencies:
       - '@types/node'
@@ -13990,7 +14002,7 @@ snapshots:
 
   possible-typed-array-names@1.0.0: {}
 
-  postcss-load-config@4.0.2(postcss@8.4.47)(ts-node@10.9.2(@types/node@22.7.9)(typescript@5.6.3)):
+  postcss-load-config@4.0.2(postcss@8.4.47)(ts-node@10.9.2(typescript@5.6.3)):
     dependencies:
       lilconfig: 3.1.2
       yaml: 2.6.0
@@ -15049,7 +15061,7 @@ snapshots:
 
   tslib@2.8.0: {}
 
-  tsup@7.3.0(postcss@8.4.47)(ts-node@10.9.2(@types/node@22.7.9)(typescript@5.6.3))(typescript@5.6.3):
+  tsup@7.3.0(postcss@8.4.47)(ts-node@10.9.2(typescript@5.6.3))(typescript@5.6.3):
     dependencies:
       bundle-require: 4.2.1(esbuild@0.19.12)
       cac: 6.7.14
@@ -15059,7 +15071,7 @@ snapshots:
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss-load-config: 4.0.2(postcss@8.4.47)(ts-node@10.9.2(@types/node@22.7.9)(typescript@5.6.3))
+      postcss-load-config: 4.0.2(postcss@8.4.47)(ts-node@10.9.2(typescript@5.6.3))
       resolve-from: 5.0.0
       rollup: 4.24.0
       source-map: 0.8.0-beta.0


### PR DESCRIPTION
## 변경사항

<!-- 어떤 변경사항이 있는지, PR 타이틀과 동일하다면 Skip -->
스타일 분기 처리를 위해 recipe 라이브러리를 설치해주었습니다.

어드민에서 사용하는 textfiled의 경우 background가 gray700으로 더 밝습니다. 
css 선택자로 스타일을 수정해주려고 했지만 input을 감싸고 있는 div를 선택하기가 애매해 mds에서 스타일 분기처리를 해주는게 더 맞다는 판단에 수정을 해보았습니다.
## 링크
https://www.figma.com/design/wQRUlMHjwFgWEvQs5tvEFO/%F0%9F%9B%A0%EF%B8%8F-%EC%96%B4%EB%93%9C%EB%AF%BC%ED%8C%80-%EC%9E%91%EC%97%85%EC%8B%A4?node-id=125-109&t=NGkbIW8i0Bb5pSB2-1
<!-- 제플린 화면 링크 또는 관련된 대화가 이루어진 slack, height, figma 링크를 첨부. -->

## 시급한 정도

🏃‍♂️ 보통 : 최대한 빠르게 리뷰 부탁드립니다.

<!-- ⚠︎ 긴급 : 선 어프루브 후 리뷰를 부탁드립니다. (리뷰는 추후 반영)  -->
<!-- 🐢 천천히 : 급하지 않습니다. -->

## 기타 사항

<!-- 변경사항이 큰 경우 집중해야 할 부분, 또는 불안해서 봐주었으면 하는 부분 등 -->

<!-- ### AS-IS -->

<!-- ### TO-BE -->
